### PR TITLE
Fix: Correct field name in create_test_members command

### DIFF
--- a/accounts/management/commands/create_test_members.py
+++ b/accounts/management/commands/create_test_members.py
@@ -15,9 +15,9 @@ class Command(BaseCommand):
         count = options['count']
         
         # Get geography data
-        provinces = list(Province.objects.filter(is_active=True))
-        lfas = list(LocalFootballAssociation.objects.filter(is_active=True))
-        clubs = list(Club.objects.filter(is_active=True))
+        provinces = list(Province.objects.all())
+        lfas = list(LocalFootballAssociation.objects.all())
+        clubs = list(Club.objects.filter(status='ACTIVE'))
         
         if not provinces or not lfas:
             self.stdout.write(


### PR DESCRIPTION
The `create_test_members` management command was using a non-existent `is_active` field to filter `Club`, `Province`, and `LocalFootballAssociation` objects. This caused a `django.core.exceptions.FieldError`.

This commit fixes the issue by:
- Replacing `Club.objects.filter(is_active=True)` with `Club.objects.filter(status='ACTIVE')` to use the correct field and value for filtering active clubs.
- Removing the `is_active` filter from the `Province` and `LocalFootballAssociation` queries, as these models do not have this field. The command will now use all available provinces and LFAs for creating test data.