### PR TITLE
Fix: Correct usage of `is_active` field across multiple files

### DIFF
--- a/accounts/management/commands/create_organization_types.py
+++ b/accounts/management/commands/create_organization_types.py
@@ -18,8 +18,7 @@ class Command(BaseCommand):
         for org_type in org_types:
             OrganizationType.objects.get_or_create(
                 name=org_type['name'],
-                level=org_type['level'],
-                defaults={'is_active': True}
+                level=org_type['level']
             )
             
         self.stdout.write(self.style.SUCCESS('Successfully created organization types'))

--- a/accounts/management/commands/setup_safa_data.py
+++ b/accounts/management/commands/setup_safa_data.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
         for level, name in org_types:
             OrganizationType.objects.get_or_create(
                 level=level,
-                defaults={'name': name, 'is_active': True}
+                defaults={'name': name}
             )
             self.stdout.write(f'Created organization type: {name}')
         

--- a/membership/forms.py
+++ b/membership/forms.py
@@ -49,7 +49,7 @@ from geography.models import Club
 
 class TransferRequestForm(forms.ModelForm):
     member = forms.ModelChoiceField(queryset=Member.objects.filter(status='ACTIVE', role='PLAYER'))
-    to_club = forms.ModelChoiceField(queryset=Club.objects.filter(is_active=True))
+    to_club = forms.ModelChoiceField(queryset=Club.objects.filter(status='ACTIVE'))
 
     class Meta:
         model = Transfer


### PR DESCRIPTION
This commit resolves a `django.core.exceptions.FieldError` caused by querying a non-existent `is_active` field on several models. The error was found in multiple management commands and forms.

The following changes have been made:
- In `accounts/management/commands/create_test_members.py` and `membership/forms.py`, `Club.objects.filter(is_active=True)` has been replaced with `Club.objects.filter(status='ACTIVE')` to correctly filter for active clubs.
- In `accounts/management/commands/create_test_members.py`, the `is_active=True` filter has been removed from queries on `Province` and `LocalFootballAssociation` models, as they do not have this field.
- In `accounts/management/commands/create_organization_types.py` and `accounts/management/commands/setup_safa_data.py`, the `is_active` field has been removed from the `defaults` dictionary when creating `OrganizationType` objects, as the model does not have this field.