### PR TITLE
fix(migrations): Remove MemberDocument operations from 0002 migration

### DIFF
--- a/membership/migrations/0002_membershipseasonhistory_officialcertification_and_more.py
+++ b/membership/migrations/0002_membershipseasonhistory_officialcertification_and_more.py
@@ -200,18 +200,6 @@ class Migration(migrations.Migration):
             model_name="clubmemberquota",
             name="season_config",
         ),
-        migrations.AlterUniqueTogether(
-            name="memberdocument",
-            unique_together=None,
-        ),
-        migrations.RemoveField(
-            model_name="memberdocument",
-            name="member",
-        ),
-        migrations.RemoveField(
-            model_name="memberdocument",
-            name="verified_by",
-        ),
         migrations.RemoveField(
             model_name="memberprofile",
             name="member",


### PR DESCRIPTION
The migration `0002_membershipseasonhistory_officialcertification_and_more` was failing on SQLite due to an incorrect order of operations. It attempted to remove fields from the `MemberDocument` model that were part of an index, before removing the index itself or the model. This caused a `FieldDoesNotExist` error during the table rebuild process.

This commit removes all operations related to `MemberDocument` from the `0002` migration file. A subsequent migration, `0003_delete_memberdocument`, already exists to handle the deletion of this model cleanly. By removing the conflicting operations from `0002`, the migration process is fixed, allowing the migrations to run successfully.