### PR TITLE
feat: Modernize login page

### DIFF
--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+
+{% block title %}Login - SAFA Connect{% endblock %}
+
+{% block content %}
+<div class="container my-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+      <div class="card shadow-lg border-0 rounded-xl">
+        <div class="card-header bg-safa-green text-white text-center">
+          <h2 class="mb-0">Member Login</h2>
+        </div>
+        <div class="card-body p-5">
+          <p class="text-center text-muted mb-4">
+            Access your SAFA dashboard.
+          </p>
+          <form method="post" class="needs-validation" novalidate>
+            {% csrf_token %}
+            {{ form|crispy }}
+            <div class="d-grid gap-2">
+              <button type="submit" class="btn btn-safa-primary btn-lg">
+                <i class="fas fa-sign-in-alt me-2"></i>Login
+              </button>
+            </div>
+          </form>
+          <hr class="my-4">
+          <div class="text-center">
+            <a href="{% url 'account_reset_password' %}" class="text-safa-green">Forgot Password?</a>
+            <p class="mt-3 text-muted">
+              Don't have an account? <a href="{% url 'account_signup' %}" class="text-safa-green fw-bold">Register here</a>.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This commit introduces a new, modernized login page template.

The new template, `templates/account/login.html`, overrides the default `django-allauth` login page. It uses Bootstrap 5 and custom styles from the `base.html` template to create a more visually appealing and user-friendly login form.

The form is rendered using `django-crispy-forms` to ensure it's styled correctly with Bootstrap 5. The new design features a card-based layout, custom brand colors, and links for password reset and user registration, improving the overall user experience.