### PR TITLE
Fix IntegrityError in generate_safa_ids admin action

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -342,19 +342,39 @@ class CustomUserAdmin(UserAdmin):
     def generate_safa_ids(self, request, queryset):
         """Generate SAFA IDs for selected users"""
         generated_count = 0
+        skipped_count = 0
         for user in queryset.filter(safa_id__isnull=True):
-            member_profile, created = Member.objects.get_or_create(user=user)
-            member_profile.generate_safa_id()
-            user.safa_id = member_profile.safa_id
-            member_profile.save()
-            user.save()
-            generated_count += 1
-        
-        self.message_user(
-            request,
-            f'{generated_count} SAFA IDs generated successfully.',
-            messages.SUCCESS
-        )
+            if user.club:
+                member_profile, created = Member.objects.get_or_create(
+                    user=user,
+                    defaults={'current_club': user.club}
+                )
+                if not member_profile.safa_id:
+                    member_profile.generate_safa_id()
+                user.safa_id = member_profile.safa_id
+                member_profile.save()
+                user.save()
+                generated_count += 1
+            else:
+                skipped_count += 1
+                self.message_user(
+                    request,
+                    f"Skipped {user.get_full_name()}: No club assigned.",
+                    messages.WARNING
+                )
+
+        if generated_count > 0:
+            self.message_user(
+                request,
+                f'{generated_count} SAFA IDs generated successfully.',
+                messages.SUCCESS
+            )
+        if skipped_count > 0:
+            self.message_user(
+                request,
+                f'{skipped_count} users were skipped because they do not have a club assigned.',
+                messages.WARNING
+            )
     generate_safa_ids.short_description = "Generate SAFA IDs for selected users"
 
     def get_organization(self, obj):


### PR DESCRIPTION
This commit fixes an `IntegrityError` that occurred when using the `generate_safa_ids` admin action for a user who did not have a `Member` profile.

The error was caused by the fact that the `Member` model has a required `current_club` field, which was not being set when the `Member` object was created.

The fix modifies the `generate_safa_ids` action to:
- Use the `user.club` as the `current_club` when creating a `Member` object.
- Skip users who do not have a `club` and display a warning message to the admin.