### PR TITLE
feat: Add custom login redirect for superusers

### DIFF
--- a/accounts/adapter.py
+++ b/accounts/adapter.py
@@ -1,0 +1,9 @@
+from allauth.account.adapter import DefaultAccountAdapter
+from django.urls import reverse
+
+class CustomAccountAdapter(DefaultAccountAdapter):
+    def get_login_redirect_url(self, request):
+        if request.user.is_superuser:
+            return reverse('superuser_dashboard')
+        else:
+            return reverse('accounts:profile')

--- a/safa_connect/settings.py
+++ b/safa_connect/settings.py
@@ -189,6 +189,7 @@ ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_USER_MODEL_USERNAME_FIELD = None
 ACCOUNT_LOGIN_METHODS = {'email'}
 ACCOUNT_SIGNUP_FIELDS = ['email', 'password1']
+ACCOUNT_ADAPTER = 'accounts.adapter.CustomAccountAdapter'
 
 
 # ACCOUNT_RATE_LIMITS = {


### PR DESCRIPTION
After logging in, superusers were being redirected to the user profile page instead of the superuser dashboard. This change introduces a custom allauth account adapter to handle login redirection. The adapter checks if the user is a superuser and, if so, redirects them to the superuser dashboard. Otherwise, it redirects them to the default profile page.