### PR TITLE
feat: Display safa_id in admin and update LFA fixture data

### DIFF
--- a/geography/fixtures/geography_localfootballassociation.json
+++ b/geography/fixtures/geography_localfootballassociation.json
@@ -3,6138 +3,5797 @@
     "model": "geography.localfootballassociation",
     "pk": 1,
     "fields": {
-      "id": "1",
-      "created": "2025-06-09 12:53:29.409550",
-      "modified": "2025-06-09 12:53:29.409581",
-      "logo": "",
-      "safa_id": "L7Q12",
       "name": "MATATIELE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "1"
+      "logo": "",
+      "safa_id": "L7Q12",
+      "region": 1,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.409550",
+      "modified": "2025-06-09 12:53:29.409581"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 2,
     "fields": {
-      "id": "2",
-      "created": "2025-06-09 12:53:29.412315",
-      "modified": "2025-06-09 12:53:29.412336",
-      "logo": "",
-      "safa_id": "2CYF8",
       "name": "MBIZANA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "1"
+      "logo": "",
+      "safa_id": "2CYF8",
+      "region": 1,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.412315",
+      "modified": "2025-06-09 12:53:29.412336"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 3,
     "fields": {
-      "id": "3",
-      "created": "2025-06-09 12:53:29.414551",
-      "modified": "2025-06-09 12:53:29.414571",
-      "logo": "",
-      "safa_id": "QHCXN",
       "name": "NTABANKULU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "1"
+      "logo": "",
+      "safa_id": "QHCXN",
+      "region": 1,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.414551",
+      "modified": "2025-06-09 12:53:29.414571"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 4,
     "fields": {
-      "id": "4",
-      "created": "2025-06-09 12:53:29.418371",
-      "modified": "2025-06-09 12:53:29.418403",
-      "logo": "",
-      "safa_id": "AN2RE",
       "name": "UMZIMVUBU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "1"
+      "logo": "",
+      "safa_id": "AN2RE",
+      "region": 1,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.418371",
+      "modified": "2025-06-09 12:53:29.418403"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 5,
     "fields": {
-      "id": "5",
-      "created": "2025-06-09 12:53:29.426088",
-      "modified": "2025-06-09 12:53:29.426108",
-      "logo": "",
-      "safa_id": "GOKLU",
       "name": "SAFA AMAHLATHI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "2"
+      "logo": "",
+      "safa_id": "GOKLU",
+      "region": 2,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.426088",
+      "modified": "2025-06-09 12:53:29.426108"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 6,
     "fields": {
-      "id": "6",
-      "created": "2025-06-09 12:53:29.428325",
-      "modified": "2025-06-09 12:53:29.428344",
-      "logo": "",
-      "safa_id": "6AKFQ",
       "name": "SAFA GREAT KEI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "2"
+      "logo": "",
+      "safa_id": "6AKFQ",
+      "region": 2,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.428325",
+      "modified": "2025-06-09 12:53:29.428344"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 7,
     "fields": {
-      "id": "7",
-      "created": "2025-06-09 12:53:29.430463",
-      "modified": "2025-06-09 12:53:29.430482",
-      "logo": "",
-      "safa_id": "F5EUW",
       "name": "SAFA MBASHE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "2"
+      "logo": "",
+      "safa_id": "F5EUW",
+      "region": 2,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.430463",
+      "modified": "2025-06-09 12:53:29.430482"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 8,
     "fields": {
-      "id": "8",
-      "created": "2025-06-09 12:53:29.432636",
-      "modified": "2025-06-09 12:53:29.432670",
-      "logo": "",
-      "safa_id": "ZUN0Y",
       "name": "SAFA MNGUMA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "2"
+      "logo": "",
+      "safa_id": "ZUN0Y",
+      "region": 2,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.432636",
+      "modified": "2025-06-09 12:53:29.432670"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 9,
     "fields": {
-      "id": "9",
-      "created": "2025-06-09 12:53:29.437451",
-      "modified": "2025-06-09 12:53:29.437498",
-      "logo": "",
-      "safa_id": "OG1JB",
       "name": "SAFA NGQUSHWA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "2"
+      "logo": "",
+      "safa_id": "OG1JB",
+      "region": 2,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.437451",
+      "modified": "2025-06-09 12:53:29.437498"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 10,
     "fields": {
-      "id": "10",
-      "created": "2025-06-09 12:53:29.441537",
-      "modified": "2025-06-09 12:53:29.441569",
-      "logo": "",
-      "safa_id": "SOWZI",
       "name": "SAFA NKONKOBE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "2"
+      "logo": "",
+      "safa_id": "SOWZI",
+      "region": 2,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.441537",
+      "modified": "2025-06-09 12:53:29.441569"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 11,
     "fields": {
-      "id": "11",
-      "created": "2025-06-09 12:53:29.444264",
-      "modified": "2025-06-09 12:53:29.444288",
-      "logo": "",
-      "safa_id": "LVI0U",
       "name": "SAFA NXUBA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "2"
+      "logo": "",
+      "safa_id": "LVI0U",
+      "region": 2,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.444264",
+      "modified": "2025-06-09 12:53:29.444288"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 12,
     "fields": {
-      "id": "12",
-      "created": "2025-06-09 12:53:29.449291",
-      "modified": "2025-06-09 12:53:29.449323",
-      "logo": "",
-      "safa_id": "A8TI7",
       "name": "SAFA BUNKERS WEST LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "3"
+      "logo": "",
+      "safa_id": "A8TI7",
+      "region": 3,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.449291",
+      "modified": "2025-06-09 12:53:29.449323"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 13,
     "fields": {
-      "id": "13",
-      "created": "2025-06-09 12:53:29.454917",
-      "modified": "2025-06-09 12:53:29.454968",
-      "logo": "",
-      "safa_id": "UG7BO",
       "name": "SAFA EAST LONDON CENTRAL LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "3"
+      "logo": "",
+      "safa_id": "UG7BO",
+      "region": 3,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.454917",
+      "modified": "2025-06-09 12:53:29.454968"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 14,
     "fields": {
-      "id": "14",
-      "created": "2025-06-09 12:53:29.458627",
-      "modified": "2025-06-09 12:53:29.458680",
-      "logo": "",
-      "safa_id": "AVA7Q",
       "name": "SAFA EAST LONDON NORTH LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "3"
+      "logo": "",
+      "safa_id": "AVA7Q",
+      "region": 3,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.458627",
+      "modified": "2025-06-09 12:53:29.458680"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 15,
     "fields": {
-      "id": "15",
-      "created": "2025-06-09 12:53:29.461155",
-      "modified": "2025-06-09 12:53:29.461176",
-      "logo": "",
-      "safa_id": "IVN2O",
       "name": "SAFA EAST LONDON WEST LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "3"
+      "logo": "",
+      "safa_id": "IVN2O",
+      "region": 3,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.461155",
+      "modified": "2025-06-09 12:53:29.461176"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 16,
     "fields": {
-      "id": "16",
-      "created": "2025-06-09 12:53:29.463365",
-      "modified": "2025-06-09 12:53:29.463383",
-      "logo": "",
-      "safa_id": "A39JB",
       "name": "SAFA KING CENTRAL LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "3"
+      "logo": "",
+      "safa_id": "A39JB",
+      "region": 3,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.463365",
+      "modified": "2025-06-09 12:53:29.463383"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 17,
     "fields": {
-      "id": "17",
-      "created": "2025-06-09 12:53:29.465539",
-      "modified": "2025-06-09 12:53:29.465558",
-      "logo": "",
-      "safa_id": "XWCC6",
       "name": "SAFA KING EAST LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "3"
+      "logo": "",
+      "safa_id": "XWCC6",
+      "region": 3,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.465539",
+      "modified": "2025-06-09 12:53:29.465558"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 18,
     "fields": {
-      "id": "18",
-      "created": "2025-06-09 12:53:29.470212",
-      "modified": "2025-06-09 12:53:29.470260",
-      "logo": "",
-      "safa_id": "GAYZ5",
       "name": "SAFA MDANTSANE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "3"
+      "logo": "",
+      "safa_id": "GAYZ5",
+      "region": 3,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.470212",
+      "modified": "2025-06-09 12:53:29.470260"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 19,
     "fields": {
-      "id": "19",
-      "created": "2025-06-09 12:53:29.473745",
-      "modified": "2025-06-09 12:53:29.473774",
-      "logo": "",
-      "safa_id": "6QERE",
       "name": "SAFA ROYAL RHARHABE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "3"
+      "logo": "",
+      "safa_id": "6QERE",
+      "region": 3,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.473745",
+      "modified": "2025-06-09 12:53:29.473774"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 20,
     "fields": {
-      "id": "20",
-      "created": "2025-06-09 12:53:29.478732",
-      "modified": "2025-06-09 12:53:29.478751",
-      "logo": "",
-      "safa_id": "B670W",
       "name": "SAFA EMALAHLENI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "4"
+      "logo": "",
+      "safa_id": "B670W",
+      "region": 4,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.478732",
+      "modified": "2025-06-09 12:53:29.478751"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 21,
     "fields": {
-      "id": "21",
-      "created": "2025-06-09 12:53:29.480900",
-      "modified": "2025-06-09 12:53:29.480919",
-      "logo": "",
-      "safa_id": "1PXFE",
       "name": "SAFA ENGCOBO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "4"
+      "logo": "",
+      "safa_id": "1PXFE",
+      "region": 4,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.480900",
+      "modified": "2025-06-09 12:53:29.480919"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 22,
     "fields": {
-      "id": "22",
-      "created": "2025-06-09 12:53:29.484333",
-      "modified": "2025-06-09 12:53:29.484444",
-      "logo": "",
-      "safa_id": "Q5K5S",
       "name": "SAFA INKWANCA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "4"
+      "logo": "",
+      "safa_id": "Q5K5S",
+      "region": 4,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.484333",
+      "modified": "2025-06-09 12:53:29.484444"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 23,
     "fields": {
-      "id": "23",
-      "created": "2025-06-09 12:53:29.488818",
-      "modified": "2025-06-09 12:53:29.488880",
-      "logo": "",
-      "safa_id": "VO4YX",
       "name": "SAFA INTSIKA YETHU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "4"
+      "logo": "",
+      "safa_id": "VO4YX",
+      "region": 4,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.488818",
+      "modified": "2025-06-09 12:53:29.488880"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 24,
     "fields": {
-      "id": "24",
-      "created": "2025-06-09 12:53:29.491406",
-      "modified": "2025-06-09 12:53:29.491431",
-      "logo": "",
-      "safa_id": "GCX8N",
       "name": "SAFA INXUBA YETHEMBA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "4"
+      "logo": "",
+      "safa_id": "GCX8N",
+      "region": 4,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.491406",
+      "modified": "2025-06-09 12:53:29.491431"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 25,
     "fields": {
-      "id": "25",
-      "created": "2025-06-09 12:53:29.493646",
-      "modified": "2025-06-09 12:53:29.493686",
-      "logo": "",
-      "safa_id": "0C7DG",
       "name": "SAFA LUKHANJI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "4"
+      "logo": "",
+      "safa_id": "0C7DG",
+      "region": 4,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.493646",
+      "modified": "2025-06-09 12:53:29.493686"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 26,
     "fields": {
-      "id": "26",
-      "created": "2025-06-09 12:53:29.496208",
-      "modified": "2025-06-09 12:53:29.496233",
-      "logo": "",
-      "safa_id": "V2EXP",
       "name": "SAFA SAKHISIZWE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "4"
+      "logo": "",
+      "safa_id": "V2EXP",
+      "region": 4,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.496208",
+      "modified": "2025-06-09 12:53:29.496233"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 27,
     "fields": {
-      "id": "27",
-      "created": "2025-06-09 12:53:29.500288",
-      "modified": "2025-06-09 12:53:29.500337",
-      "logo": "",
-      "safa_id": "FE9VK",
       "name": "SAFA TSOLWANA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "4"
+      "logo": "",
+      "safa_id": "FE9VK",
+      "region": 4,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.500288",
+      "modified": "2025-06-09 12:53:29.500337"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 28,
     "fields": {
-      "id": "28",
-      "created": "2025-06-09 12:53:29.506167",
-      "modified": "2025-06-09 12:53:29.506186",
-      "logo": "",
-      "safa_id": "3EO8Q",
       "name": "SAFA ELUNDI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "5"
+      "logo": "",
+      "safa_id": "3EO8Q",
+      "region": 5,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.506167",
+      "modified": "2025-06-09 12:53:29.506186"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 29,
     "fields": {
-      "id": "29",
-      "created": "2025-06-09 12:53:29.508393",
-      "modified": "2025-06-09 12:53:29.508412",
-      "logo": "",
-      "safa_id": "17EXV",
       "name": "SAFA GARIEP LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "5"
+      "logo": "",
+      "safa_id": "17EXV",
+      "region": 5,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.508393",
+      "modified": "2025-06-09 12:53:29.508412"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 30,
     "fields": {
-      "id": "30",
-      "created": "2025-06-09 12:53:29.510615",
-      "modified": "2025-06-09 12:53:29.510634",
-      "logo": "",
-      "safa_id": "8FIBY",
       "name": "SAFA MALETSWAI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "5"
+      "logo": "",
+      "safa_id": "8FIBY",
+      "region": 5,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.510615",
+      "modified": "2025-06-09 12:53:29.510634"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 31,
     "fields": {
-      "id": "31",
-      "created": "2025-06-09 12:53:29.512854",
-      "modified": "2025-06-09 12:53:29.512873",
-      "logo": "",
-      "safa_id": "UZ5LR",
       "name": "SAFA SENQU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "5"
+      "logo": "",
+      "safa_id": "UZ5LR",
+      "region": 5,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.512854",
+      "modified": "2025-06-09 12:53:29.512873"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 32,
     "fields": {
-      "id": "32",
-      "created": "2025-06-09 12:53:29.519438",
-      "modified": "2025-06-09 12:53:29.519486",
-      "logo": "",
-      "safa_id": "T8D0F",
       "name": "SAFA KUYGA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "6"
+      "logo": "",
+      "safa_id": "T8D0F",
+      "region": 6,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.519438",
+      "modified": "2025-06-09 12:53:29.519486"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 33,
     "fields": {
-      "id": "33",
-      "created": "2025-06-09 12:53:29.521931",
-      "modified": "2025-06-09 12:53:29.521956",
-      "logo": "",
-      "safa_id": "6ERO4",
       "name": "SAFA LAROFA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "6"
+      "logo": "",
+      "safa_id": "6ERO4",
+      "region": 6,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.521931",
+      "modified": "2025-06-09 12:53:29.521956"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 34,
     "fields": {
-      "id": "34",
-      "created": "2025-06-09 12:53:29.524195",
-      "modified": "2025-06-09 12:53:29.524215",
-      "logo": "",
-      "safa_id": "5G70H",
       "name": "SAFA MOTHERWELL LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "6"
+      "logo": "",
+      "safa_id": "5G70H",
+      "region": 6,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.524195",
+      "modified": "2025-06-09 12:53:29.524215"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 35,
     "fields": {
-      "id": "35",
-      "created": "2025-06-09 12:53:29.526383",
-      "modified": "2025-06-09 12:53:29.526402",
-      "logo": "",
-      "safa_id": "OJ3LH",
       "name": "SAFA NAFA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "6"
+      "logo": "",
+      "safa_id": "OJ3LH",
+      "region": 6,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.526383",
+      "modified": "2025-06-09 12:53:29.526402"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 36,
     "fields": {
-      "id": "36",
-      "created": "2025-06-09 12:53:29.528564",
-      "modified": "2025-06-09 12:53:29.528584",
-      "logo": "",
-      "safa_id": "YXDB1",
       "name": "SAFA NEW BRIGHTON LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "6"
+      "logo": "",
+      "safa_id": "YXDB1",
+      "region": 6,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.528564",
+      "modified": "2025-06-09 12:53:29.528584"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 37,
     "fields": {
-      "id": "37",
-      "created": "2025-06-09 12:53:29.530693",
-      "modified": "2025-06-09 12:53:29.530712",
-      "logo": "",
-      "safa_id": "0X0Q0",
       "name": "SAFA NODEFA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "6"
+      "logo": "",
+      "safa_id": "0X0Q0",
+      "region": 6,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.530693",
+      "modified": "2025-06-09 12:53:29.530712"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 38,
     "fields": {
-      "id": "38",
-      "created": "2025-06-09 12:53:29.533476",
-      "modified": "2025-06-09 12:53:29.533509",
-      "logo": "",
-      "safa_id": "W6CR2",
       "name": "SAFA PEEFA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "6"
+      "logo": "",
+      "safa_id": "W6CR2",
+      "region": 6,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.533476",
+      "modified": "2025-06-09 12:53:29.533509"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 39,
     "fields": {
-      "id": "39",
-      "created": "2025-06-09 12:53:29.536045",
-      "modified": "2025-06-09 12:53:29.536077",
-      "logo": "",
-      "safa_id": "QXO7R",
       "name": "SAFA PENFA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "6"
+      "logo": "",
+      "safa_id": "QXO7R",
+      "region": 6,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.536045",
+      "modified": "2025-06-09 12:53:29.536077"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 40,
     "fields": {
-      "id": "40",
-      "created": "2025-06-09 12:53:29.540181",
-      "modified": "2025-06-09 12:53:29.540222",
-      "logo": "",
-      "safa_id": "LIZJY",
       "name": "SAFA PORT ELIZABETH LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "6"
+      "logo": "",
+      "safa_id": "LIZJY",
+      "region": 6,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.540181",
+      "modified": "2025-06-09 12:53:29.540222"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 41,
     "fields": {
-      "id": "41",
-      "created": "2025-06-09 12:53:29.543754",
-      "modified": "2025-06-09 12:53:29.543788",
-      "logo": "",
-      "safa_id": "W5OKL",
       "name": "SAFA WALMER LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "6"
+      "logo": "",
+      "safa_id": "W5OKL",
+      "region": 6,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.543754",
+      "modified": "2025-06-09 12:53:29.543788"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 42,
     "fields": {
-      "id": "42",
-      "created": "2025-06-09 12:53:29.547402",
-      "modified": "2025-06-09 12:53:29.547431",
-      "logo": "",
-      "safa_id": "WVFXT",
       "name": "SAFA ZAFA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "6"
+      "logo": "",
+      "safa_id": "WVFXT",
+      "region": 6,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.547402",
+      "modified": "2025-06-09 12:53:29.547431"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 43,
     "fields": {
-      "id": "43",
-      "created": "2025-06-09 12:53:29.549979",
-      "modified": "2025-06-09 12:53:29.550002",
-      "logo": "",
-      "safa_id": "RN1U3",
       "name": "SAFA ZWIDE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "6"
+      "logo": "",
+      "safa_id": "RN1U3",
+      "region": 6,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.549979",
+      "modified": "2025-06-09 12:53:29.550002"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 44,
     "fields": {
-      "id": "44",
-      "created": "2025-06-09 12:53:29.556322",
-      "modified": "2025-06-09 12:53:29.556348",
-      "logo": "",
-      "safa_id": "MAUPN",
       "name": "SAFA INGQUZA HILL LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "7"
+      "logo": "",
+      "safa_id": "MAUPN",
+      "region": 7,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.556322",
+      "modified": "2025-06-09 12:53:29.556348"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 45,
     "fields": {
-      "id": "45",
-      "created": "2025-06-09 12:53:29.558770",
-      "modified": "2025-06-09 12:53:29.558791",
-      "logo": "",
-      "safa_id": "GUWZK",
       "name": "SAFA KING SABATA DALINDYEBO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "7"
+      "logo": "",
+      "safa_id": "GUWZK",
+      "region": 7,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.558770",
+      "modified": "2025-06-09 12:53:29.558791"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 46,
     "fields": {
-      "id": "46",
-      "created": "2025-06-09 12:53:29.561188",
-      "modified": "2025-06-09 12:53:29.561210",
-      "logo": "",
-      "safa_id": "52UN6",
       "name": "SAFA MHLONTLO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "7"
+      "logo": "",
+      "safa_id": "52UN6",
+      "region": 7,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.561188",
+      "modified": "2025-06-09 12:53:29.561210"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 47,
     "fields": {
-      "id": "47",
-      "created": "2025-06-09 12:53:29.563580",
-      "modified": "2025-06-09 12:53:29.563602",
-      "logo": "",
-      "safa_id": "UKCLF",
       "name": "SAFA NYANDENI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "7"
+      "logo": "",
+      "safa_id": "UKCLF",
+      "region": 7,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.563580",
+      "modified": "2025-06-09 12:53:29.563602"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 48,
     "fields": {
-      "id": "48",
-      "created": "2025-06-09 12:53:29.566006",
-      "modified": "2025-06-09 12:53:29.566028",
-      "logo": "",
-      "safa_id": "AAP9A",
       "name": "SAFA PORT ST JOHN\u2019S LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "7"
+      "logo": "",
+      "safa_id": "AAP9A",
+      "region": 7,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.566006",
+      "modified": "2025-06-09 12:53:29.566028"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 49,
     "fields": {
-      "id": "49",
-      "created": "2025-06-09 12:53:29.572750",
-      "modified": "2025-06-09 12:53:29.572781",
-      "logo": "",
-      "safa_id": "QGUQB",
       "name": "SAFA BLUE CRANE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "8"
+      "logo": "",
+      "safa_id": "QGUQB",
+      "region": 8,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.572750",
+      "modified": "2025-06-09 12:53:29.572781"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 50,
     "fields": {
-      "id": "50",
-      "created": "2025-06-09 12:53:29.575284",
-      "modified": "2025-06-09 12:53:29.575311",
-      "logo": "",
-      "safa_id": "DIN05",
       "name": "SAFA CAMDEBOO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "8"
+      "logo": "",
+      "safa_id": "DIN05",
+      "region": 8,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.575284",
+      "modified": "2025-06-09 12:53:29.575311"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 51,
     "fields": {
-      "id": "51",
-      "created": "2025-06-09 12:53:29.577820",
-      "modified": "2025-06-09 12:53:29.577854",
-      "logo": "",
-      "safa_id": "WHQOF",
       "name": "SAFA IKQWEZI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "8"
+      "logo": "",
+      "safa_id": "WHQOF",
+      "region": 8,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.577820",
+      "modified": "2025-06-09 12:53:29.577854"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 52,
     "fields": {
-      "id": "52",
-      "created": "2025-06-09 12:53:29.580948",
-      "modified": "2025-06-09 12:53:29.580977",
-      "logo": "",
-      "safa_id": "HBX2E",
       "name": "SAFA KOUGA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "8"
+      "logo": "",
+      "safa_id": "HBX2E",
+      "region": 8,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.580948",
+      "modified": "2025-06-09 12:53:29.580977"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 53,
     "fields": {
-      "id": "53",
-      "created": "2025-06-09 12:53:29.583539",
-      "modified": "2025-06-09 12:53:29.583565",
-      "logo": "",
-      "safa_id": "O4HKK",
       "name": "SAFA KOUKAMA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "8"
+      "logo": "",
+      "safa_id": "O4HKK",
+      "region": 8,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.583539",
+      "modified": "2025-06-09 12:53:29.583565"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 54,
     "fields": {
-      "id": "54",
-      "created": "2025-06-09 12:53:29.586546",
-      "modified": "2025-06-09 12:53:29.586580",
-      "logo": "",
-      "safa_id": "SCMOB",
       "name": "SAFA MAKANA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "8"
+      "logo": "",
+      "safa_id": "SCMOB",
+      "region": 8,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.586546",
+      "modified": "2025-06-09 12:53:29.586580"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 55,
     "fields": {
-      "id": "55",
-      "created": "2025-06-09 12:53:29.589683",
-      "modified": "2025-06-09 12:53:29.589721",
-      "logo": "",
-      "safa_id": "WGF87",
       "name": "SAFA NDLAMBE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "8"
+      "logo": "",
+      "safa_id": "WGF87",
+      "region": 8,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.589683",
+      "modified": "2025-06-09 12:53:29.589721"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 56,
     "fields": {
-      "id": "56",
-      "created": "2025-06-09 12:53:29.592892",
-      "modified": "2025-06-09 12:53:29.592922",
-      "logo": "",
-      "safa_id": "YCDEK",
       "name": "SAFA SUNDAY`S RIVER LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "8"
+      "logo": "",
+      "safa_id": "YCDEK",
+      "region": 8,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.592892",
+      "modified": "2025-06-09 12:53:29.592922"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 57,
     "fields": {
-      "id": "57",
-      "created": "2025-06-09 12:53:29.598764",
-      "modified": "2025-06-09 12:53:29.598784",
-      "logo": "",
-      "safa_id": "G7OEV",
       "name": "SAFA MAFUBE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "9"
+      "logo": "",
+      "safa_id": "G7OEV",
+      "region": 9,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.598764",
+      "modified": "2025-06-09 12:53:29.598784"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 58,
     "fields": {
-      "id": "58",
-      "created": "2025-06-09 12:53:29.602475",
-      "modified": "2025-06-09 12:53:29.602524",
-      "logo": "",
-      "safa_id": "TIJD7",
       "name": "SAFA METSIMAHOLO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "9"
+      "logo": "",
+      "safa_id": "TIJD7",
+      "region": 9,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.602475",
+      "modified": "2025-06-09 12:53:29.602524"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 59,
     "fields": {
-      "id": "59",
-      "created": "2025-06-09 12:53:29.606632",
-      "modified": "2025-06-09 12:53:29.606675",
-      "logo": "",
-      "safa_id": "6IJU4",
       "name": "SAFA MOQHAKA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "9"
+      "logo": "",
+      "safa_id": "6IJU4",
+      "region": 9,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.606632",
+      "modified": "2025-06-09 12:53:29.606675"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 60,
     "fields": {
-      "id": "60",
-      "created": "2025-06-09 12:53:29.609074",
-      "modified": "2025-06-09 12:53:29.609095",
-      "logo": "",
-      "safa_id": "STDZ4",
       "name": "SAFA NGWATHE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "9"
+      "logo": "",
+      "safa_id": "STDZ4",
+      "region": 9,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.609074",
+      "modified": "2025-06-09 12:53:29.609095"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 61,
     "fields": {
-      "id": "61",
-      "created": "2025-06-09 12:53:29.614119",
-      "modified": "2025-06-09 12:53:29.614139",
-      "logo": "",
-      "safa_id": "E85M3",
       "name": "SAFA MASILONYANA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "10"
+      "logo": "",
+      "safa_id": "E85M3",
+      "region": 10,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.614119",
+      "modified": "2025-06-09 12:53:29.614139"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 62,
     "fields": {
-      "id": "62",
-      "created": "2025-06-09 12:53:29.616859",
-      "modified": "2025-06-09 12:53:29.616885",
-      "logo": "",
-      "safa_id": "28KF0",
       "name": "SAFA MATJHABENG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "10"
+      "logo": "",
+      "safa_id": "28KF0",
+      "region": 10,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.616859",
+      "modified": "2025-06-09 12:53:29.616885"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 63,
     "fields": {
-      "id": "63",
-      "created": "2025-06-09 12:53:29.620027",
-      "modified": "2025-06-09 12:53:29.620054",
-      "logo": "",
-      "safa_id": "EQV06",
       "name": "SAFA NALA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "10"
+      "logo": "",
+      "safa_id": "EQV06",
+      "region": 10,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.620027",
+      "modified": "2025-06-09 12:53:29.620054"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 64,
     "fields": {
-      "id": "64",
-      "created": "2025-06-09 12:53:29.622489",
-      "modified": "2025-06-09 12:53:29.622529",
-      "logo": "",
-      "safa_id": "XOA0G",
       "name": "SAFA TOKOLOGO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "10"
+      "logo": "",
+      "safa_id": "XOA0G",
+      "region": 10,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.622489",
+      "modified": "2025-06-09 12:53:29.622529"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 65,
     "fields": {
-      "id": "65",
-      "created": "2025-06-09 12:53:29.625020",
-      "modified": "2025-06-09 12:53:29.625041",
-      "logo": "",
-      "safa_id": "P4O69",
       "name": "SAFA TSWELOPELE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "10"
+      "logo": "",
+      "safa_id": "P4O69",
+      "region": 10,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.625020",
+      "modified": "2025-06-09 12:53:29.625041"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 66,
     "fields": {
-      "id": "66",
-      "created": "2025-06-09 12:53:29.630073",
-      "modified": "2025-06-09 12:53:29.630092",
-      "logo": "",
-      "safa_id": "TM7RJ",
       "name": "SAFA BLOEMFONTEIN LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "11"
+      "logo": "",
+      "safa_id": "TM7RJ",
+      "region": 11,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.630073",
+      "modified": "2025-06-09 12:53:29.630092"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 67,
     "fields": {
-      "id": "67",
-      "created": "2025-06-09 12:53:29.632237",
-      "modified": "2025-06-09 12:53:29.632257",
-      "logo": "",
-      "safa_id": "HLOTG",
       "name": "SAFA BOTSHABELO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "11"
+      "logo": "",
+      "safa_id": "HLOTG",
+      "region": 11,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.632237",
+      "modified": "2025-06-09 12:53:29.632257"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 68,
     "fields": {
-      "id": "68",
-      "created": "2025-06-09 12:53:29.635135",
-      "modified": "2025-06-09 12:53:29.635163",
-      "logo": "",
-      "safa_id": "2RIT5",
       "name": "SAFA THABA NCHU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "11"
+      "logo": "",
+      "safa_id": "2RIT5",
+      "region": 11,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.635135",
+      "modified": "2025-06-09 12:53:29.635163"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 69,
     "fields": {
-      "id": "69",
-      "created": "2025-06-09 12:53:29.640321",
-      "modified": "2025-06-09 12:53:29.640341",
-      "logo": "",
-      "safa_id": "1OT5Y",
       "name": "SAFA DIHLABENG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "12"
+      "logo": "",
+      "safa_id": "1OT5Y",
+      "region": 12,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.640321",
+      "modified": "2025-06-09 12:53:29.640341"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 70,
     "fields": {
-      "id": "70",
-      "created": "2025-06-09 12:53:29.642595",
-      "modified": "2025-06-09 12:53:29.642614",
-      "logo": "",
-      "safa_id": "QC1VD",
       "name": "SAFA MALUTI-A-PHOFUNG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "12"
+      "logo": "",
+      "safa_id": "QC1VD",
+      "region": 12,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.642595",
+      "modified": "2025-06-09 12:53:29.642614"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 71,
     "fields": {
-      "id": "71",
-      "created": "2025-06-09 12:53:29.644801",
-      "modified": "2025-06-09 12:53:29.644820",
-      "logo": "",
-      "safa_id": "NB2D7",
       "name": "SAFA MANTSOPA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "12"
+      "logo": "",
+      "safa_id": "NB2D7",
+      "region": 12,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.644801",
+      "modified": "2025-06-09 12:53:29.644820"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 72,
     "fields": {
-      "id": "72",
-      "created": "2025-06-09 12:53:29.646956",
-      "modified": "2025-06-09 12:53:29.646976",
-      "logo": "",
-      "safa_id": "6M8MC",
       "name": "SAFA NKETOANE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "12"
+      "logo": "",
+      "safa_id": "6M8MC",
+      "region": 12,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.646956",
+      "modified": "2025-06-09 12:53:29.646976"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 73,
     "fields": {
-      "id": "73",
-      "created": "2025-06-09 12:53:29.649342",
-      "modified": "2025-06-09 12:53:29.649370",
-      "logo": "",
-      "safa_id": "EBG5K",
       "name": "SAFA PHUMELELA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "12"
+      "logo": "",
+      "safa_id": "EBG5K",
+      "region": 12,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.649342",
+      "modified": "2025-06-09 12:53:29.649370"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 74,
     "fields": {
-      "id": "74",
-      "created": "2025-06-09 12:53:29.652641",
-      "modified": "2025-06-09 12:53:29.652700",
-      "logo": "",
-      "safa_id": "6T7AD",
       "name": "SAFA SETSOTO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "12"
+      "logo": "",
+      "safa_id": "6T7AD",
+      "region": 12,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.652641",
+      "modified": "2025-06-09 12:53:29.652700"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 75,
     "fields": {
-      "id": "75",
-      "created": "2025-06-09 12:53:29.657756",
-      "modified": "2025-06-09 12:53:29.657777",
-      "logo": "",
-      "safa_id": "FNOF6",
       "name": "SAFA KOPANONG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "13"
+      "logo": "",
+      "safa_id": "FNOF6",
+      "region": 13,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.657756",
+      "modified": "2025-06-09 12:53:29.657777"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 76,
     "fields": {
-      "id": "76",
-      "created": "2025-06-09 12:53:29.659935",
-      "modified": "2025-06-09 12:53:29.659955",
-      "logo": "",
-      "safa_id": "N5O38",
       "name": "SAFA LETSEMENG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "13"
+      "logo": "",
+      "safa_id": "N5O38",
+      "region": 13,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.659935",
+      "modified": "2025-06-09 12:53:29.659955"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 77,
     "fields": {
-      "id": "77",
-      "created": "2025-06-09 12:53:29.662189",
-      "modified": "2025-06-09 12:53:29.662209",
-      "logo": "",
-      "safa_id": "GLAH2",
       "name": "SAFA MOHOKARE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "13"
+      "logo": "",
+      "safa_id": "GLAH2",
+      "region": 13,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.662189",
+      "modified": "2025-06-09 12:53:29.662209"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 78,
     "fields": {
-      "id": "78",
-      "created": "2025-06-09 12:53:29.664473",
-      "modified": "2025-06-09 12:53:29.664493",
-      "logo": "",
-      "safa_id": "J97E7",
       "name": "SAFA NALEDI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "13"
+      "logo": "",
+      "safa_id": "J97E7",
+      "region": 13,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.664473",
+      "modified": "2025-06-09 12:53:29.664493"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 79,
     "fields": {
-      "id": "79",
-      "created": "2025-06-09 12:53:29.671431",
-      "modified": "2025-06-09 12:53:29.671456",
-      "logo": "",
-      "safa_id": "LAWM2",
       "name": "SAFA BENONI NORTH LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "14"
+      "logo": "",
+      "safa_id": "LAWM2",
+      "region": 14,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.671431",
+      "modified": "2025-06-09 12:53:29.671456"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 80,
     "fields": {
-      "id": "80",
-      "created": "2025-06-09 12:53:29.673714",
-      "modified": "2025-06-09 12:53:29.673735",
-      "logo": "",
-      "safa_id": "TABTK",
       "name": "SAFA BENONI SOUTH LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "14"
+      "logo": "",
+      "safa_id": "TABTK",
+      "region": 14,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.673714",
+      "modified": "2025-06-09 12:53:29.673735"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 81,
     "fields": {
-      "id": "81",
-      "created": "2025-06-09 12:53:29.675902",
-      "modified": "2025-06-09 12:53:29.675922",
-      "logo": "",
-      "safa_id": "AAGRM",
       "name": "SAFA BOKSBURG & CENTRAL LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "14"
+      "logo": "",
+      "safa_id": "AAGRM",
+      "region": 14,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.675902",
+      "modified": "2025-06-09 12:53:29.675922"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 82,
     "fields": {
-      "id": "82",
-      "created": "2025-06-09 12:53:29.678140",
-      "modified": "2025-06-09 12:53:29.678160",
-      "logo": "",
-      "safa_id": "8XE5K",
       "name": "SAFA BRAKPAN LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "14"
+      "logo": "",
+      "safa_id": "8XE5K",
+      "region": 14,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.678140",
+      "modified": "2025-06-09 12:53:29.678160"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 83,
     "fields": {
-      "id": "83",
-      "created": "2025-06-09 12:53:29.680303",
-      "modified": "2025-06-09 12:53:29.680322",
-      "logo": "",
-      "safa_id": "YBBQ9",
       "name": "SAFA DUKATHOLE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "14"
+      "logo": "",
+      "safa_id": "YBBQ9",
+      "region": 14,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.680303",
+      "modified": "2025-06-09 12:53:29.680322"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 84,
     "fields": {
-      "id": "84",
-      "created": "2025-06-09 12:53:29.682584",
-      "modified": "2025-06-09 12:53:29.682612",
-      "logo": "",
-      "safa_id": "TPFX7",
       "name": "SAFA EASTERNS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "14"
+      "logo": "",
+      "safa_id": "TPFX7",
+      "region": 14,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.682584",
+      "modified": "2025-06-09 12:53:29.682612"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 85,
     "fields": {
-      "id": "85",
-      "created": "2025-06-09 12:53:29.685232",
-      "modified": "2025-06-09 12:53:29.685257",
-      "logo": "",
-      "safa_id": "MW9TB",
       "name": "SAFA EDEN PARK LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "14"
+      "logo": "",
+      "safa_id": "MW9TB",
+      "region": 14,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.685232",
+      "modified": "2025-06-09 12:53:29.685257"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 86,
     "fields": {
-      "id": "86",
-      "created": "2025-06-09 12:53:29.688260",
-      "modified": "2025-06-09 12:53:29.688285",
-      "logo": "",
-      "safa_id": "815Y7",
       "name": "SAFA KATLEHONG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "14"
+      "logo": "",
+      "safa_id": "815Y7",
+      "region": 14,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.688260",
+      "modified": "2025-06-09 12:53:29.688285"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 87,
     "fields": {
-      "id": "87",
-      "created": "2025-06-09 12:53:29.690624",
-      "modified": "2025-06-09 12:53:29.690648",
-      "logo": "",
-      "safa_id": "FZO5Y",
       "name": "SAFA NIGEL LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "14"
+      "logo": "",
+      "safa_id": "FZO5Y",
+      "region": 14,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.690624",
+      "modified": "2025-06-09 12:53:29.690648"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 88,
     "fields": {
-      "id": "88",
-      "created": "2025-06-09 12:53:29.692937",
-      "modified": "2025-06-09 12:53:29.692958",
-      "logo": "",
-      "safa_id": "NPT5F",
       "name": "SAFA PAYNEVILLE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "14"
+      "logo": "",
+      "safa_id": "NPT5F",
+      "region": 14,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.692937",
+      "modified": "2025-06-09 12:53:29.692958"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 89,
     "fields": {
-      "id": "89",
-      "created": "2025-06-09 12:53:29.695181",
-      "modified": "2025-06-09 12:53:29.695201",
-      "logo": "",
-      "safa_id": "U6U77",
       "name": "SAFA SPRINGS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "14"
+      "logo": "",
+      "safa_id": "U6U77",
+      "region": 14,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.695181",
+      "modified": "2025-06-09 12:53:29.695201"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 90,
     "fields": {
-      "id": "90",
-      "created": "2025-06-09 12:53:29.697370",
-      "modified": "2025-06-09 12:53:29.697389",
-      "logo": "",
-      "safa_id": "2ZH8C",
       "name": "SAFA THEMBISA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "14"
+      "logo": "",
+      "safa_id": "2ZH8C",
+      "region": 14,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.697370",
+      "modified": "2025-06-09 12:53:29.697389"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 91,
     "fields": {
-      "id": "91",
-      "created": "2025-06-09 12:53:29.699910",
-      "modified": "2025-06-09 12:53:29.699933",
-      "logo": "",
-      "safa_id": "QE5SZ",
       "name": "SAFA THOKOZA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "14"
+      "logo": "",
+      "safa_id": "QE5SZ",
+      "region": 14,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.699910",
+      "modified": "2025-06-09 12:53:29.699933"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 92,
     "fields": {
-      "id": "92",
-      "created": "2025-06-09 12:53:29.702242",
-      "modified": "2025-06-09 12:53:29.702262",
-      "logo": "",
-      "safa_id": "G1JT4",
       "name": "SAFA VOSLOORUS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "14"
+      "logo": "",
+      "safa_id": "G1JT4",
+      "region": 14,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.702242",
+      "modified": "2025-06-09 12:53:29.702262"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 93,
     "fields": {
-      "id": "93",
-      "created": "2025-06-09 12:53:29.704438",
-      "modified": "2025-06-09 12:53:29.704458",
-      "logo": "",
-      "safa_id": "FWFYV",
       "name": "SAFA ZONKEZIZWE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "14"
+      "logo": "",
+      "safa_id": "FWFYV",
+      "region": 14,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.704438",
+      "modified": "2025-06-09 12:53:29.704458"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 94,
     "fields": {
-      "id": "94",
-      "created": "2025-06-09 12:53:29.709564",
-      "modified": "2025-06-09 12:53:29.709586",
-      "logo": "",
-      "safa_id": "0OBWF",
       "name": "SAFA ALEX NORTH RAND LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "15"
+      "logo": "",
+      "safa_id": "0OBWF",
+      "region": 15,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.709564",
+      "modified": "2025-06-09 12:53:29.709586"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 95,
     "fields": {
-      "id": "95",
-      "created": "2025-06-09 12:53:29.711807",
-      "modified": "2025-06-09 12:53:29.711827",
-      "logo": "",
-      "safa_id": "GOODF",
       "name": "SAFA DEEP SOUTH LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "15"
+      "logo": "",
+      "safa_id": "GOODF",
+      "region": 15,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.711807",
+      "modified": "2025-06-09 12:53:29.711827"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 96,
     "fields": {
-      "id": "96",
-      "created": "2025-06-09 12:53:29.714051",
-      "modified": "2025-06-09 12:53:29.714070",
-      "logo": "",
-      "safa_id": "6QGAM",
       "name": "SAFA ELDORADO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "15"
+      "logo": "",
+      "safa_id": "6QGAM",
+      "region": 15,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.714051",
+      "modified": "2025-06-09 12:53:29.714070"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 97,
     "fields": {
-      "id": "97",
-      "created": "2025-06-09 12:53:29.716419",
-      "modified": "2025-06-09 12:53:29.716439",
-      "logo": "",
-      "safa_id": "3VCQV",
       "name": "SAFA GREATER MAYFAIR LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "15"
+      "logo": "",
+      "safa_id": "3VCQV",
+      "region": 15,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.716419",
+      "modified": "2025-06-09 12:53:29.716439"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 98,
     "fields": {
-      "id": "98",
-      "created": "2025-06-09 12:53:29.719154",
-      "modified": "2025-06-09 12:53:29.719189",
-      "logo": "",
-      "safa_id": "BN4ZU",
       "name": "SAFA JOWEST LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "15"
+      "logo": "",
+      "safa_id": "BN4ZU",
+      "region": 15,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.719154",
+      "modified": "2025-06-09 12:53:29.719189"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 99,
     "fields": {
-      "id": "99",
-      "created": "2025-06-09 12:53:29.722271",
-      "modified": "2025-06-09 12:53:29.722297",
-      "logo": "",
-      "safa_id": "16AO4",
       "name": "SAFA MIDRAND LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "15"
+      "logo": "",
+      "safa_id": "16AO4",
+      "region": 15,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.722271",
+      "modified": "2025-06-09 12:53:29.722297"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 100,
     "fields": {
-      "id": "100",
-      "created": "2025-06-09 12:53:29.724565",
-      "modified": "2025-06-09 12:53:29.724585",
-      "logo": "",
-      "safa_id": "EYJN6",
       "name": "SAFA ORANGE FARM LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "15"
+      "logo": "",
+      "safa_id": "EYJN6",
+      "region": 15,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.724565",
+      "modified": "2025-06-09 12:53:29.724585"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 101,
     "fields": {
-      "id": "101",
-      "created": "2025-06-09 12:53:29.726750",
-      "modified": "2025-06-09 12:53:29.726771",
-      "logo": "",
-      "safa_id": "YGKDO",
       "name": "SAFA RAND CENTRAL LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "15"
+      "logo": "",
+      "safa_id": "YGKDO",
+      "region": 15,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.726750",
+      "modified": "2025-06-09 12:53:29.726771"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 102,
     "fields": {
-      "id": "102",
-      "created": "2025-06-09 12:53:29.728961",
-      "modified": "2025-06-09 12:53:29.728981",
-      "logo": "",
-      "safa_id": "LZR3I",
       "name": "SAFA ROODEPOORT LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "15"
+      "logo": "",
+      "safa_id": "LZR3I",
+      "region": 15,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.728961",
+      "modified": "2025-06-09 12:53:29.728981"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 103,
     "fields": {
-      "id": "103",
-      "created": "2025-06-09 12:53:29.731113",
-      "modified": "2025-06-09 12:53:29.731132",
-      "logo": "",
-      "safa_id": "Q8B0I",
       "name": "SAFA SOUTHERN LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "15"
+      "logo": "",
+      "safa_id": "Q8B0I",
+      "region": 15,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.731113",
+      "modified": "2025-06-09 12:53:29.731132"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 104,
     "fields": {
-      "id": "104",
-      "created": "2025-06-09 12:53:29.733437",
-      "modified": "2025-06-09 12:53:29.733457",
-      "logo": "",
-      "safa_id": "QNZDA",
       "name": "SAFA SOWETO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "15"
+      "logo": "",
+      "safa_id": "QNZDA",
+      "region": 15,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.733437",
+      "modified": "2025-06-09 12:53:29.733457"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 105,
     "fields": {
-      "id": "105",
-      "created": "2025-06-09 12:53:29.735618",
-      "modified": "2025-06-09 12:53:29.735637",
-      "logo": "",
-      "safa_id": "TDYGZ",
       "name": "SAFA UPPER SOWETO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "15"
+      "logo": "",
+      "safa_id": "TDYGZ",
+      "region": 15,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.735618",
+      "modified": "2025-06-09 12:53:29.735637"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 106,
     "fields": {
-      "id": "106",
-      "created": "2025-06-09 12:53:29.740309",
-      "modified": "2025-06-09 12:53:29.740328",
-      "logo": "",
-      "safa_id": "EB07X",
       "name": "SAFA EMFULENI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "16"
+      "logo": "",
+      "safa_id": "EB07X",
+      "region": 16,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.740309",
+      "modified": "2025-06-09 12:53:29.740328"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 107,
     "fields": {
-      "id": "107",
-      "created": "2025-06-09 12:53:29.742460",
-      "modified": "2025-06-09 12:53:29.742479",
-      "logo": "",
-      "safa_id": "ZAN42",
       "name": "SAFA LESEDI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "16"
+      "logo": "",
+      "safa_id": "ZAN42",
+      "region": 16,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.742460",
+      "modified": "2025-06-09 12:53:29.742479"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 108,
     "fields": {
-      "id": "108",
-      "created": "2025-06-09 12:53:29.744585",
-      "modified": "2025-06-09 12:53:29.744605",
-      "logo": "",
-      "safa_id": "PY6LK",
       "name": "SAFA MIDVAAL LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "16"
+      "logo": "",
+      "safa_id": "PY6LK",
+      "region": 16,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.744585",
+      "modified": "2025-06-09 12:53:29.744605"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 109,
     "fields": {
-      "id": "109",
-      "created": "2025-06-09 12:53:29.749340",
-      "modified": "2025-06-09 12:53:29.749359",
-      "logo": "",
-      "safa_id": "8ICLL",
       "name": "SAFA EERSTERUS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "8ICLL",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.749340",
+      "modified": "2025-06-09 12:53:29.749359"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 110,
     "fields": {
-      "id": "110",
-      "created": "2025-06-09 12:53:29.751841",
-      "modified": "2025-06-09 12:53:29.751867",
-      "logo": "",
-      "safa_id": "BNQBR",
       "name": "SAFA GA-RANKUWA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "BNQBR",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.751841",
+      "modified": "2025-06-09 12:53:29.751867"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 111,
     "fields": {
-      "id": "111",
-      "created": "2025-06-09 12:53:29.755610",
-      "modified": "2025-06-09 12:53:29.755670",
-      "logo": "",
-      "safa_id": "TGHT3",
       "name": "SAFA HAMMANSKRAAL LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "TGHT3",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.755610",
+      "modified": "2025-06-09 12:53:29.755670"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 112,
     "fields": {
-      "id": "112",
-      "created": "2025-06-09 12:53:29.759895",
-      "modified": "2025-06-09 12:53:29.759939",
-      "logo": "",
-      "safa_id": "AGKPL",
       "name": "SAFA KULFA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "AGKPL",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.759895",
+      "modified": "2025-06-09 12:53:29.759939"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 113,
     "fields": {
-      "id": "113",
-      "created": "2025-06-09 12:53:29.764188",
-      "modified": "2025-06-09 12:53:29.764238",
-      "logo": "",
-      "safa_id": "4YVT4",
       "name": "SAFA LAUDIUM LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "4YVT4",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.764188",
+      "modified": "2025-06-09 12:53:29.764238"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 114,
     "fields": {
-      "id": "114",
-      "created": "2025-06-09 12:53:29.768941",
-      "modified": "2025-06-09 12:53:29.768989",
-      "logo": "",
-      "safa_id": "OVE5O",
       "name": "SAFA LOTUS GARDEN LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "OVE5O",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.768941",
+      "modified": "2025-06-09 12:53:29.768989"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 115,
     "fields": {
-      "id": "115",
-      "created": "2025-06-09 12:53:29.773325",
-      "modified": "2025-06-09 12:53:29.773372",
-      "logo": "",
-      "safa_id": "W860F",
       "name": "SAFA MABOPANE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "W860F",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.773325",
+      "modified": "2025-06-09 12:53:29.773372"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 116,
     "fields": {
-      "id": "116",
-      "created": "2025-06-09 12:53:29.777459",
-      "modified": "2025-06-09 12:53:29.777508",
-      "logo": "",
-      "safa_id": "1I8Y3",
       "name": "SAFA MAMELODI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "1I8Y3",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.777459",
+      "modified": "2025-06-09 12:53:29.777508"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 117,
     "fields": {
-      "id": "117",
-      "created": "2025-06-09 12:53:29.781725",
-      "modified": "2025-06-09 12:53:29.781768",
-      "logo": "",
-      "safa_id": "B1ZIQ",
       "name": "SAFA NOLFA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "B1ZIQ",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.781725",
+      "modified": "2025-06-09 12:53:29.781768"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 118,
     "fields": {
-      "id": "118",
-      "created": "2025-06-09 12:53:29.785565",
-      "modified": "2025-06-09 12:53:29.785604",
-      "logo": "",
-      "safa_id": "QWKJY",
       "name": "SAFA OLFA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "QWKJY",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.785565",
+      "modified": "2025-06-09 12:53:29.785604"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 119,
     "fields": {
-      "id": "119",
-      "created": "2025-06-09 12:53:29.789496",
-      "modified": "2025-06-09 12:53:29.789546",
-      "logo": "",
-      "safa_id": "64IJ7",
       "name": "SAFA PHELINDABA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "64IJ7",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.789496",
+      "modified": "2025-06-09 12:53:29.789546"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 120,
     "fields": {
-      "id": "120",
-      "created": "2025-06-09 12:53:29.793709",
-      "modified": "2025-06-09 12:53:29.793757",
-      "logo": "",
-      "safa_id": "U2ETT",
       "name": "SAFA PRETORIA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "U2ETT",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.793709",
+      "modified": "2025-06-09 12:53:29.793757"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 121,
     "fields": {
-      "id": "121",
-      "created": "2025-06-09 12:53:29.797562",
-      "modified": "2025-06-09 12:53:29.797603",
-      "logo": "",
-      "safa_id": "ZRVHK",
       "name": "SAFA SELFA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "ZRVHK",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.797562",
+      "modified": "2025-06-09 12:53:29.797603"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 122,
     "fields": {
-      "id": "122",
-      "created": "2025-06-09 12:53:29.801163",
-      "modified": "2025-06-09 12:53:29.801209",
-      "logo": "",
-      "safa_id": "S3X4H",
       "name": "SAFA SOSHANGUVE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "S3X4H",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.801163",
+      "modified": "2025-06-09 12:53:29.801209"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 123,
     "fields": {
-      "id": "123",
-      "created": "2025-06-09 12:53:29.805498",
-      "modified": "2025-06-09 12:53:29.805549",
-      "logo": "",
-      "safa_id": "BK7R6",
       "name": "SAFA WEST END LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "BK7R6",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.805498",
+      "modified": "2025-06-09 12:53:29.805549"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 124,
     "fields": {
-      "id": "124",
-      "created": "2025-06-09 12:53:29.809263",
-      "modified": "2025-06-09 12:53:29.809300",
-      "logo": "",
-      "safa_id": "GGEP9",
       "name": "SAFA WINTERVELDT LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "17"
+      "logo": "",
+      "safa_id": "GGEP9",
+      "region": 17,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.809263",
+      "modified": "2025-06-09 12:53:29.809300"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 125,
     "fields": {
-      "id": "125",
-      "created": "2025-06-09 12:53:29.818237",
-      "modified": "2025-06-09 12:53:29.818277",
-      "logo": "",
-      "safa_id": "TRZZ0",
       "name": "SAFA MERAFONG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "18"
+      "logo": "",
+      "safa_id": "TRZZ0",
+      "region": 18,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.818237",
+      "modified": "2025-06-09 12:53:29.818277"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 126,
     "fields": {
-      "id": "126",
-      "created": "2025-06-09 12:53:29.821593",
-      "modified": "2025-06-09 12:53:29.821627",
-      "logo": "",
-      "safa_id": "WJO4G",
       "name": "SAFA MOGALE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "18"
+      "logo": "",
+      "safa_id": "WJO4G",
+      "region": 18,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.821593",
+      "modified": "2025-06-09 12:53:29.821627"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 127,
     "fields": {
-      "id": "127",
-      "created": "2025-06-09 12:53:29.824914",
-      "modified": "2025-06-09 12:53:29.824943",
-      "logo": "",
-      "safa_id": "3SV4M",
       "name": "SAFA RANDFONTEIN LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "18"
+      "logo": "",
+      "safa_id": "3SV4M",
+      "region": 18,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.824914",
+      "modified": "2025-06-09 12:53:29.824943"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 128,
     "fields": {
-      "id": "128",
-      "created": "2025-06-09 12:53:29.827718",
-      "modified": "2025-06-09 12:53:29.827761",
-      "logo": "",
-      "safa_id": "GTI5F",
       "name": "SAFA WESTONARIA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "18"
+      "logo": "",
+      "safa_id": "GTI5F",
+      "region": 18,
+      "association": 4,
+      "created": "2025-06-09 12:53:29.827718",
+      "modified": "2025-06-09 12:53:29.827761"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 129,
     "fields": {
-      "id": "129",
-      "created": "2025-06-09 13:21:59.222115",
-      "modified": "2025-06-09 13:21:59.222150",
-      "logo": "",
-      "safa_id": "MGJMH",
       "name": "SAFA DANNHAUSER LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "19"
+      "logo": "",
+      "safa_id": "MGJMH",
+      "region": 19,
+      "association": 4,
+      "created": "2025-06-09 13:21:59.222115",
+      "modified": "2025-06-09 13:21:59.222150"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 130,
     "fields": {
-      "id": "130",
-      "created": "2025-06-09 13:21:59.239867",
-      "modified": "2025-06-09 13:21:59.239896",
-      "logo": "",
-      "safa_id": "KZW8V",
       "name": "SAFA EMANDLANGENI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "19"
+      "logo": "",
+      "safa_id": "KZW8V",
+      "region": 19,
+      "association": 4,
+      "created": "2025-06-09 13:21:59.239867",
+      "modified": "2025-06-09 13:21:59.239896"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 131,
     "fields": {
-      "id": "131",
-      "created": "2025-06-09 13:21:59.243450",
-      "modified": "2025-06-09 13:21:59.243487",
-      "logo": "",
-      "safa_id": "POP8I",
       "name": "SAFA NEWCASTLE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "19"
+      "logo": "",
+      "safa_id": "POP8I",
+      "region": 19,
+      "association": 4,
+      "created": "2025-06-09 13:21:59.243450",
+      "modified": "2025-06-09 13:21:59.243487"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 132,
     "fields": {
-      "id": "132",
-      "created": "2025-06-09 13:24:17.831673",
-      "modified": "2025-06-09 13:24:17.831729",
-      "logo": "",
-      "safa_id": "IFJSO",
       "name": "SAFA AMANZIMTOTI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "IFJSO",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.831673",
+      "modified": "2025-06-09 13:24:17.831729"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 133,
     "fields": {
-      "id": "133",
-      "created": "2025-06-09 13:24:17.834604",
-      "modified": "2025-06-09 13:24:17.834629",
-      "logo": "",
-      "safa_id": "WKBK5",
       "name": "SAFA CHATSWORTH LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "WKBK5",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.834604",
+      "modified": "2025-06-09 13:24:17.834629"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 134,
     "fields": {
-      "id": "134",
-      "created": "2025-06-09 13:24:17.836789",
-      "modified": "2025-06-09 13:24:17.836809",
-      "logo": "",
-      "safa_id": "MGXDM",
       "name": "SAFA CLERMONT LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "MGXDM",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.836789",
+      "modified": "2025-06-09 13:24:17.836809"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 135,
     "fields": {
-      "id": "135",
-      "created": "2025-06-09 13:24:17.838900",
-      "modified": "2025-06-09 13:24:17.838920",
-      "logo": "",
-      "safa_id": "R3CLK",
       "name": "SAFA DURBAN CENTRAL LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "R3CLK",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.838900",
+      "modified": "2025-06-09 13:24:17.838920"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 136,
     "fields": {
-      "id": "136",
-      "created": "2025-06-09 13:24:17.841249",
-      "modified": "2025-06-09 13:24:17.841269",
-      "logo": "",
-      "safa_id": "Y8U4Q",
       "name": "SAFA DURBAN SOUTH LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "Y8U4Q",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.841249",
+      "modified": "2025-06-09 13:24:17.841269"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 137,
     "fields": {
-      "id": "137",
-      "created": "2025-06-09 13:24:17.843422",
-      "modified": "2025-06-09 13:24:17.843444",
-      "logo": "",
-      "safa_id": "T9GPH",
       "name": "SAFA GREATER CATO RIDGE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "T9GPH",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.843422",
+      "modified": "2025-06-09 13:24:17.843444"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 138,
     "fields": {
-      "id": "138",
-      "created": "2025-06-09 13:24:17.846123",
-      "modified": "2025-06-09 13:24:17.846149",
-      "logo": "",
-      "safa_id": "PQRFG",
       "name": "SAFA GREATER HILLCREST LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "PQRFG",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.846123",
+      "modified": "2025-06-09 13:24:17.846149"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 139,
     "fields": {
-      "id": "139",
-      "created": "2025-06-09 13:24:17.848381",
-      "modified": "2025-06-09 13:24:17.848401",
-      "logo": "",
-      "safa_id": "BUXJ3",
       "name": "SAFA HAMMARSDALE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "BUXJ3",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.848381",
+      "modified": "2025-06-09 13:24:17.848401"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 140,
     "fields": {
-      "id": "140",
-      "created": "2025-06-09 13:24:17.850587",
-      "modified": "2025-06-09 13:24:17.850606",
-      "logo": "",
-      "safa_id": "W0E40",
       "name": "SAFA INANDA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "W0E40",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.850587",
+      "modified": "2025-06-09 13:24:17.850606"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 141,
     "fields": {
-      "id": "141",
-      "created": "2025-06-09 13:24:17.852741",
-      "modified": "2025-06-09 13:24:17.852760",
-      "logo": "",
-      "safa_id": "B10W2",
       "name": "SAFA KWAMASHU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "B10W2",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.852741",
+      "modified": "2025-06-09 13:24:17.852760"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 142,
     "fields": {
-      "id": "142",
-      "created": "2025-06-09 13:24:17.854833",
-      "modified": "2025-06-09 13:24:17.854852",
-      "logo": "",
-      "safa_id": "0HBZF",
       "name": "SAFA NTUZUMA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "0HBZF",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.854833",
+      "modified": "2025-06-09 13:24:17.854852"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 143,
     "fields": {
-      "id": "143",
-      "created": "2025-06-09 13:24:17.857097",
-      "modified": "2025-06-09 13:24:17.857116",
-      "logo": "",
-      "safa_id": "OOPGV",
       "name": "SAFA PHOENIX LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "OOPGV",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.857097",
+      "modified": "2025-06-09 13:24:17.857116"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 144,
     "fields": {
-      "id": "144",
-      "created": "2025-06-09 13:24:17.859248",
-      "modified": "2025-06-09 13:24:17.859268",
-      "logo": "",
-      "safa_id": "8MVEA",
       "name": "SAFA PINETOWN LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "8MVEA",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.859248",
+      "modified": "2025-06-09 13:24:17.859268"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 145,
     "fields": {
-      "id": "145",
-      "created": "2025-06-09 13:24:17.861803",
-      "modified": "2025-06-09 13:24:17.861828",
-      "logo": "",
-      "safa_id": "DJHCS",
       "name": "SAFA PINETOWN SOUTH LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "DJHCS",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.861803",
+      "modified": "2025-06-09 13:24:17.861828"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 146,
     "fields": {
-      "id": "146",
-      "created": "2025-06-09 13:24:17.864009",
-      "modified": "2025-06-09 13:24:17.864029",
-      "logo": "",
-      "safa_id": "62194",
       "name": "SAFA REUNION LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "62194",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.864009",
+      "modified": "2025-06-09 13:24:17.864029"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 147,
     "fields": {
-      "id": "147",
-      "created": "2025-06-09 13:24:17.866210",
-      "modified": "2025-06-09 13:24:17.866230",
-      "logo": "",
-      "safa_id": "XLAYA",
       "name": "SAFA TONGAAT LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "XLAYA",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.866210",
+      "modified": "2025-06-09 13:24:17.866230"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 148,
     "fields": {
-      "id": "148",
-      "created": "2025-06-09 13:24:17.868297",
-      "modified": "2025-06-09 13:24:17.868315",
-      "logo": "",
-      "safa_id": "W2WCA",
       "name": "SAFA UMBUMBULU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "W2WCA",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.868297",
+      "modified": "2025-06-09 13:24:17.868315"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 149,
     "fields": {
-      "id": "149",
-      "created": "2025-06-09 13:24:17.870379",
-      "modified": "2025-06-09 13:24:17.870398",
-      "logo": "",
-      "safa_id": "KQA6V",
       "name": "SAFA UMLAZI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "KQA6V",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.870379",
+      "modified": "2025-06-09 13:24:17.870398"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 150,
     "fields": {
-      "id": "150",
-      "created": "2025-06-09 13:24:17.872452",
-      "modified": "2025-06-09 13:24:17.872472",
-      "logo": "",
-      "safa_id": "3LE2L",
       "name": "SAFA UMKHOMAZI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "3LE2L",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.872452",
+      "modified": "2025-06-09 13:24:17.872472"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 151,
     "fields": {
-      "id": "151",
-      "created": "2025-06-09 13:24:17.874690",
-      "modified": "2025-06-09 13:24:17.874710",
-      "logo": "",
-      "safa_id": "KEJLU",
       "name": "SAFA VERULAM LF LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "20"
+      "logo": "",
+      "safa_id": "KEJLU",
+      "region": 20,
+      "association": 4,
+      "created": "2025-06-09 13:24:17.874690",
+      "modified": "2025-06-09 13:24:17.874710"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 152,
     "fields": {
-      "id": "152",
-      "created": "2025-06-09 13:25:25.999360",
-      "modified": "2025-06-09 13:25:25.999399",
-      "logo": "",
-      "safa_id": "UM88U",
       "name": "SAFA EBUHLEBEZWE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "21"
+      "logo": "",
+      "safa_id": "UM88U",
+      "region": 21,
+      "association": 4,
+      "created": "2025-06-09 13:25:25.999360",
+      "modified": "2025-06-09 13:25:25.999399"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 153,
     "fields": {
-      "id": "153",
-      "created": "2025-06-09 13:25:26.002304",
-      "modified": "2025-06-09 13:25:26.002328",
-      "logo": "",
-      "safa_id": "EQ7PN",
       "name": "SAFA GREATER KOKSTAD LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "21"
+      "logo": "",
+      "safa_id": "EQ7PN",
+      "region": 21,
+      "association": 4,
+      "created": "2025-06-09 13:25:26.002304",
+      "modified": "2025-06-09 13:25:26.002328"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 154,
     "fields": {
-      "id": "154",
-      "created": "2025-06-09 13:25:26.004630",
-      "modified": "2025-06-09 13:25:26.004671",
-      "logo": "",
-      "safa_id": "1T5O9",
       "name": "SAFA INGWE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "21"
+      "logo": "",
+      "safa_id": "1T5O9",
+      "region": 21,
+      "association": 4,
+      "created": "2025-06-09 13:25:26.004630",
+      "modified": "2025-06-09 13:25:26.004671"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 155,
     "fields": {
-      "id": "155",
-      "created": "2025-06-09 13:25:26.007291",
-      "modified": "2025-06-09 13:25:26.007320",
-      "logo": "",
-      "safa_id": "QSU59",
       "name": "SAFA KWA SANI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "21"
+      "logo": "",
+      "safa_id": "QSU59",
+      "region": 21,
+      "association": 4,
+      "created": "2025-06-09 13:25:26.007291",
+      "modified": "2025-06-09 13:25:26.007320"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 156,
     "fields": {
-      "id": "156",
-      "created": "2025-06-09 13:25:26.010217",
-      "modified": "2025-06-09 13:25:26.010243",
-      "logo": "",
-      "safa_id": "MJUY1",
       "name": "SAFA UMZIMKHULU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "21"
+      "logo": "",
+      "safa_id": "MJUY1",
+      "region": 21,
+      "association": 4,
+      "created": "2025-06-09 13:25:26.010217",
+      "modified": "2025-06-09 13:25:26.010243"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 157,
     "fields": {
-      "id": "157",
-      "created": "2025-06-09 13:26:15.222797",
-      "modified": "2025-06-09 13:26:15.222833",
-      "logo": "",
-      "safa_id": "L73FZ",
       "name": "SAFA KWADUKUZA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "22"
+      "logo": "",
+      "safa_id": "L73FZ",
+      "region": 22,
+      "association": 4,
+      "created": "2025-06-09 13:26:15.222797",
+      "modified": "2025-06-09 13:26:15.222833"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 158,
     "fields": {
-      "id": "158",
-      "created": "2025-06-09 13:26:15.225688",
-      "modified": "2025-06-09 13:26:15.225713",
-      "logo": "",
-      "safa_id": "7VNVF",
       "name": "SAFA MANDENI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "22"
+      "logo": "",
+      "safa_id": "7VNVF",
+      "region": 22,
+      "association": 4,
+      "created": "2025-06-09 13:26:15.225688",
+      "modified": "2025-06-09 13:26:15.225713"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 159,
     "fields": {
-      "id": "159",
-      "created": "2025-06-09 13:26:15.227890",
-      "modified": "2025-06-09 13:26:15.227910",
-      "logo": "",
-      "safa_id": "FP6R6",
       "name": "SAFA MAPHUMULO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "22"
+      "logo": "",
+      "safa_id": "FP6R6",
+      "region": 22,
+      "association": 4,
+      "created": "2025-06-09 13:26:15.227890",
+      "modified": "2025-06-09 13:26:15.227910"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 160,
     "fields": {
-      "id": "160",
-      "created": "2025-06-09 13:26:15.230062",
-      "modified": "2025-06-09 13:26:15.230082",
-      "logo": "",
-      "safa_id": "LUR5A",
       "name": "SAFA NDWENDWE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "22"
+      "logo": "",
+      "safa_id": "LUR5A",
+      "region": 22,
+      "association": 4,
+      "created": "2025-06-09 13:26:15.230062",
+      "modified": "2025-06-09 13:26:15.230082"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 161,
     "fields": {
-      "id": "161",
-      "created": "2025-06-09 13:27:11.256159",
-      "modified": "2025-06-09 13:27:11.256217",
-      "logo": "",
-      "safa_id": "IJ1QW",
       "name": "SAFA MFOLOZI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "23"
+      "logo": "",
+      "safa_id": "IJ1QW",
+      "region": 23,
+      "association": 4,
+      "created": "2025-06-09 13:27:11.256159",
+      "modified": "2025-06-09 13:27:11.256217"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 162,
     "fields": {
-      "id": "162",
-      "created": "2025-06-09 13:27:11.260634",
-      "modified": "2025-06-09 13:27:11.260699",
-      "logo": "",
-      "safa_id": "E2LQI",
       "name": "SAFA MTAMBANANA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "23"
+      "logo": "",
+      "safa_id": "E2LQI",
+      "region": 23,
+      "association": 4,
+      "created": "2025-06-09 13:27:11.260634",
+      "modified": "2025-06-09 13:27:11.260699"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 163,
     "fields": {
-      "id": "163",
-      "created": "2025-06-09 13:27:11.263059",
-      "modified": "2025-06-09 13:27:11.263082",
-      "logo": "",
-      "safa_id": "HAR13",
       "name": "SAFA MTHONJANENI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "23"
+      "logo": "",
+      "safa_id": "HAR13",
+      "region": 23,
+      "association": 4,
+      "created": "2025-06-09 13:27:11.263059",
+      "modified": "2025-06-09 13:27:11.263082"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 164,
     "fields": {
-      "id": "164",
-      "created": "2025-06-09 13:27:11.265375",
-      "modified": "2025-06-09 13:27:11.265398",
-      "logo": "",
-      "safa_id": "X5IXX",
       "name": "SAFA NKANDLA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "23"
+      "logo": "",
+      "safa_id": "X5IXX",
+      "region": 23,
+      "association": 4,
+      "created": "2025-06-09 13:27:11.265375",
+      "modified": "2025-06-09 13:27:11.265398"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 165,
     "fields": {
-      "id": "165",
-      "created": "2025-06-09 13:27:11.267796",
-      "modified": "2025-06-09 13:27:11.267816",
-      "logo": "",
-      "safa_id": "Q32B0",
       "name": "SAFA UMLALAZI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "23"
+      "logo": "",
+      "safa_id": "Q32B0",
+      "region": 23,
+      "association": 4,
+      "created": "2025-06-09 13:27:11.267796",
+      "modified": "2025-06-09 13:27:11.267816"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 166,
     "fields": {
-      "id": "166",
-      "created": "2025-06-09 13:27:11.269932",
-      "modified": "2025-06-09 13:27:11.269951",
-      "logo": "",
-      "safa_id": "XW5R2",
       "name": "SAFA UMHLATHUZE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "23"
+      "logo": "",
+      "safa_id": "XW5R2",
+      "region": 23,
+      "association": 4,
+      "created": "2025-06-09 13:27:11.269932",
+      "modified": "2025-06-09 13:27:11.269951"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 167,
     "fields": {
-      "id": "167",
-      "created": "2025-06-09 13:28:11.027317",
-      "modified": "2025-06-09 13:28:11.027352",
-      "logo": "",
-      "safa_id": "UWPTR",
       "name": "SAFA EZINGOLENI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "24"
+      "logo": "",
+      "safa_id": "UWPTR",
+      "region": 24,
+      "association": 4,
+      "created": "2025-06-09 13:28:11.027317",
+      "modified": "2025-06-09 13:28:11.027352"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 168,
     "fields": {
-      "id": "168",
-      "created": "2025-06-09 13:28:11.030512",
-      "modified": "2025-06-09 13:28:11.030544",
-      "logo": "",
-      "safa_id": "CVFTX",
       "name": "SAFA HIBISCUS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "24"
+      "logo": "",
+      "safa_id": "CVFTX",
+      "region": 24,
+      "association": 4,
+      "created": "2025-06-09 13:28:11.030512",
+      "modified": "2025-06-09 13:28:11.030544"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 169,
     "fields": {
-      "id": "169",
-      "created": "2025-06-09 13:28:11.033340",
-      "modified": "2025-06-09 13:28:11.033387",
-      "logo": "",
-      "safa_id": "5AYHX",
       "name": "SAFA UMDONI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "24"
+      "logo": "",
+      "safa_id": "5AYHX",
+      "region": 24,
+      "association": 4,
+      "created": "2025-06-09 13:28:11.033340",
+      "modified": "2025-06-09 13:28:11.033387"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 170,
     "fields": {
-      "id": "170",
-      "created": "2025-06-09 13:28:11.035818",
-      "modified": "2025-06-09 13:28:11.035839",
-      "logo": "",
-      "safa_id": "QR0VO",
       "name": "SAFA UMUZIWABANTU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "24"
+      "logo": "",
+      "safa_id": "QR0VO",
+      "region": 24,
+      "association": 4,
+      "created": "2025-06-09 13:28:11.035818",
+      "modified": "2025-06-09 13:28:11.035839"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 171,
     "fields": {
-      "id": "171",
-      "created": "2025-06-09 13:28:11.038557",
-      "modified": "2025-06-09 13:28:11.038588",
-      "logo": "",
-      "safa_id": "MXO7P",
       "name": "SAFA UMZUMBE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "24"
+      "logo": "",
+      "safa_id": "MXO7P",
+      "region": 24,
+      "association": 4,
+      "created": "2025-06-09 13:28:11.038557",
+      "modified": "2025-06-09 13:28:11.038588"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 172,
     "fields": {
-      "id": "172",
-      "created": "2025-06-09 13:29:45.710407",
-      "modified": "2025-06-09 13:29:45.710470",
-      "logo": "",
-      "safa_id": "RXUQS",
       "name": "SAFA IMPENDLE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "25"
+      "logo": "",
+      "safa_id": "RXUQS",
+      "region": 25,
+      "association": 4,
+      "created": "2025-06-09 13:29:45.710407",
+      "modified": "2025-06-09 13:29:45.710470"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 173,
     "fields": {
-      "id": "173",
-      "created": "2025-06-09 13:29:45.713938",
-      "modified": "2025-06-09 13:29:45.713966",
-      "logo": "",
-      "safa_id": "4XZKV",
       "name": "SAFA MKHAMBATHINI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "25"
+      "logo": "",
+      "safa_id": "4XZKV",
+      "region": 25,
+      "association": 4,
+      "created": "2025-06-09 13:29:45.713938",
+      "modified": "2025-06-09 13:29:45.713966"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 174,
     "fields": {
-      "id": "174",
-      "created": "2025-06-09 13:29:45.716542",
-      "modified": "2025-06-09 13:29:45.716565",
-      "logo": "",
-      "safa_id": "V5MU5",
       "name": "SAFA MPOFANA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "25"
+      "logo": "",
+      "safa_id": "V5MU5",
+      "region": 25,
+      "association": 4,
+      "created": "2025-06-09 13:29:45.716542",
+      "modified": "2025-06-09 13:29:45.716565"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 175,
     "fields": {
-      "id": "175",
-      "created": "2025-06-09 13:29:45.718944",
-      "modified": "2025-06-09 13:29:45.718967",
-      "logo": "",
-      "safa_id": "R50U9",
       "name": "SAFA MSUNDUZI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "25"
+      "logo": "",
+      "safa_id": "R50U9",
+      "region": 25,
+      "association": 4,
+      "created": "2025-06-09 13:29:45.718944",
+      "modified": "2025-06-09 13:29:45.718967"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 176,
     "fields": {
-      "id": "176",
-      "created": "2025-06-09 13:29:45.721782",
-      "modified": "2025-06-09 13:29:45.721816",
-      "logo": "",
-      "safa_id": "BQ9FX",
       "name": "SAFA RICHMOND LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "25"
+      "logo": "",
+      "safa_id": "BQ9FX",
+      "region": 25,
+      "association": 4,
+      "created": "2025-06-09 13:29:45.721782",
+      "modified": "2025-06-09 13:29:45.721816"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 177,
     "fields": {
-      "id": "177",
-      "created": "2025-06-09 13:29:45.724365",
-      "modified": "2025-06-09 13:29:45.724392",
-      "logo": "",
-      "safa_id": "UU3BN",
       "name": "SAFA UMNGENI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "25"
+      "logo": "",
+      "safa_id": "UU3BN",
+      "region": 25,
+      "association": 4,
+      "created": "2025-06-09 13:29:45.724365",
+      "modified": "2025-06-09 13:29:45.724392"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 178,
     "fields": {
-      "id": "178",
-      "created": "2025-06-09 13:29:45.726988",
-      "modified": "2025-06-09 13:29:45.727012",
-      "logo": "",
-      "safa_id": "5QDVC",
       "name": "SAFA UMSHWATI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "25"
+      "logo": "",
+      "safa_id": "5QDVC",
+      "region": 25,
+      "association": 4,
+      "created": "2025-06-09 13:29:45.726988",
+      "modified": "2025-06-09 13:29:45.727012"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 179,
     "fields": {
-      "id": "179",
-      "created": "2025-06-09 13:30:46.730926",
-      "modified": "2025-06-09 13:30:46.730961",
-      "logo": "",
-      "safa_id": "QKHKS",
       "name": "SAFA HLABISA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "26"
+      "logo": "",
+      "safa_id": "QKHKS",
+      "region": 26,
+      "association": 4,
+      "created": "2025-06-09 13:30:46.730926",
+      "modified": "2025-06-09 13:30:46.730961"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 180,
     "fields": {
-      "id": "180",
-      "created": "2025-06-09 13:30:46.734027",
-      "modified": "2025-06-09 13:30:46.734053",
-      "logo": "",
-      "safa_id": "XVWYM",
       "name": "SAFA JOZINI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "26"
+      "logo": "",
+      "safa_id": "XVWYM",
+      "region": 26,
+      "association": 4,
+      "created": "2025-06-09 13:30:46.734027",
+      "modified": "2025-06-09 13:30:46.734053"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 181,
     "fields": {
-      "id": "181",
-      "created": "2025-06-09 13:30:46.736245",
-      "modified": "2025-06-09 13:30:46.736265",
-      "logo": "",
-      "safa_id": "1WKBD",
       "name": "SAFA MTUBATUBA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "26"
+      "logo": "",
+      "safa_id": "1WKBD",
+      "region": 26,
+      "association": 4,
+      "created": "2025-06-09 13:30:46.736245",
+      "modified": "2025-06-09 13:30:46.736265"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 182,
     "fields": {
-      "id": "182",
-      "created": "2025-06-09 13:30:46.738450",
-      "modified": "2025-06-09 13:30:46.738469",
-      "logo": "",
-      "safa_id": "BATUP",
       "name": "SAFA THE BIG 5 FALSE BAY LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "26"
+      "logo": "",
+      "safa_id": "BATUP",
+      "region": 26,
+      "association": 4,
+      "created": "2025-06-09 13:30:46.738450",
+      "modified": "2025-06-09 13:30:46.738469"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 183,
     "fields": {
-      "id": "183",
-      "created": "2025-06-09 13:30:46.740718",
-      "modified": "2025-06-09 13:30:46.740737",
-      "logo": "",
-      "safa_id": "N4SGM",
       "name": "SAFA UMHLABUYALINGANA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "26"
+      "logo": "",
+      "safa_id": "N4SGM",
+      "region": 26,
+      "association": 4,
+      "created": "2025-06-09 13:30:46.740718",
+      "modified": "2025-06-09 13:30:46.740737"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 184,
     "fields": {
-      "id": "184",
-      "created": "2025-06-09 13:31:37.045648",
-      "modified": "2025-06-09 13:31:37.045727",
-      "logo": "",
-      "safa_id": "IA4Y4",
       "name": "SAFA EMDUMENI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "27"
+      "logo": "",
+      "safa_id": "IA4Y4",
+      "region": 27,
+      "association": 4,
+      "created": "2025-06-09 13:31:37.045648",
+      "modified": "2025-06-09 13:31:37.045727"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 185,
     "fields": {
-      "id": "185",
-      "created": "2025-06-09 13:31:37.051037",
-      "modified": "2025-06-09 13:31:37.051081",
-      "logo": "",
-      "safa_id": "DY5L3",
       "name": "SAFA MSINGA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "27"
+      "logo": "",
+      "safa_id": "DY5L3",
+      "region": 27,
+      "association": 4,
+      "created": "2025-06-09 13:31:37.051037",
+      "modified": "2025-06-09 13:31:37.051081"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 186,
     "fields": {
-      "id": "186",
-      "created": "2025-06-09 13:31:37.055365",
-      "modified": "2025-06-09 13:31:37.055407",
-      "logo": "",
-      "safa_id": "6UYFW",
       "name": "SAFA NQUTHU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "27"
+      "logo": "",
+      "safa_id": "6UYFW",
+      "region": 27,
+      "association": 4,
+      "created": "2025-06-09 13:31:37.055365",
+      "modified": "2025-06-09 13:31:37.055407"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 187,
     "fields": {
-      "id": "187",
-      "created": "2025-06-09 13:31:37.060616",
-      "modified": "2025-06-09 13:31:37.060685",
-      "logo": "",
-      "safa_id": "P9WRD",
       "name": "SAFA UMVOTI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "27"
+      "logo": "",
+      "safa_id": "P9WRD",
+      "region": 27,
+      "association": 4,
+      "created": "2025-06-09 13:31:37.060616",
+      "modified": "2025-06-09 13:31:37.060685"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 188,
     "fields": {
-      "id": "188",
-      "created": "2025-06-09 13:33:00.565857",
-      "modified": "2025-06-09 13:33:00.565892",
-      "logo": "",
-      "safa_id": "BES0N",
       "name": "SAFA EMNAMBITHI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "28"
+      "logo": "",
+      "safa_id": "BES0N",
+      "region": 28,
+      "association": 4,
+      "created": "2025-06-09 13:33:00.565857",
+      "modified": "2025-06-09 13:33:00.565892"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 189,
     "fields": {
-      "id": "189",
-      "created": "2025-06-09 13:33:00.568933",
-      "modified": "2025-06-09 13:33:00.568971",
-      "logo": "",
-      "safa_id": "LUW2V",
       "name": "SAFA IMBABAZANE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "28"
+      "logo": "",
+      "safa_id": "LUW2V",
+      "region": 28,
+      "association": 4,
+      "created": "2025-06-09 13:33:00.568933",
+      "modified": "2025-06-09 13:33:00.568971"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 190,
     "fields": {
-      "id": "190",
-      "created": "2025-06-09 13:33:00.571357",
-      "modified": "2025-06-09 13:33:00.571379",
-      "logo": "",
-      "safa_id": "GKU8T",
       "name": "SAFA INDAKA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "28"
+      "logo": "",
+      "safa_id": "GKU8T",
+      "region": 28,
+      "association": 4,
+      "created": "2025-06-09 13:33:00.571357",
+      "modified": "2025-06-09 13:33:00.571379"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 191,
     "fields": {
-      "id": "191",
-      "created": "2025-06-09 13:33:00.573497",
-      "modified": "2025-06-09 13:33:00.573517",
-      "logo": "",
-      "safa_id": "50IL8",
       "name": "SAFA UKHAHLAMBA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "28"
+      "logo": "",
+      "safa_id": "50IL8",
+      "region": 28,
+      "association": 4,
+      "created": "2025-06-09 13:33:00.573497",
+      "modified": "2025-06-09 13:33:00.573517"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 192,
     "fields": {
-      "id": "192",
-      "created": "2025-06-09 13:33:00.575806",
-      "modified": "2025-06-09 13:33:00.575825",
-      "logo": "",
-      "safa_id": "ICJUF",
       "name": "SAFA UMTSHEZI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "28"
+      "logo": "",
+      "safa_id": "ICJUF",
+      "region": 28,
+      "association": 4,
+      "created": "2025-06-09 13:33:00.575806",
+      "modified": "2025-06-09 13:33:00.575825"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 193,
     "fields": {
-      "id": "193",
-      "created": "2025-06-09 13:33:56.702938",
-      "modified": "2025-06-09 13:33:56.702980",
-      "logo": "",
-      "safa_id": "OW77Q",
       "name": "SAFA ABAQULUSI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "29"
+      "logo": "",
+      "safa_id": "OW77Q",
+      "region": 29,
+      "association": 4,
+      "created": "2025-06-09 13:33:56.702938",
+      "modified": "2025-06-09 13:33:56.702980"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 194,
     "fields": {
-      "id": "194",
-      "created": "2025-06-09 13:33:56.705883",
-      "modified": "2025-06-09 13:33:56.705907",
-      "logo": "",
-      "safa_id": "GML3S",
       "name": "SAFA EDUMBE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "29"
+      "logo": "",
+      "safa_id": "GML3S",
+      "region": 29,
+      "association": 4,
+      "created": "2025-06-09 13:33:56.705883",
+      "modified": "2025-06-09 13:33:56.705907"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 195,
     "fields": {
-      "id": "195",
-      "created": "2025-06-09 13:33:56.708627",
-      "modified": "2025-06-09 13:33:56.708670",
-      "logo": "",
-      "safa_id": "7DLNI",
       "name": "SAFA NONGOMA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "29"
+      "logo": "",
+      "safa_id": "7DLNI",
+      "region": 29,
+      "association": 4,
+      "created": "2025-06-09 13:33:56.708627",
+      "modified": "2025-06-09 13:33:56.708670"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 196,
     "fields": {
-      "id": "196",
-      "created": "2025-06-09 13:33:56.710862",
-      "modified": "2025-06-09 13:33:56.710883",
-      "logo": "",
-      "safa_id": "OA7PE",
       "name": "SAFA ULUNDI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "29"
+      "logo": "",
+      "safa_id": "OA7PE",
+      "region": 29,
+      "association": 4,
+      "created": "2025-06-09 13:33:56.710862",
+      "modified": "2025-06-09 13:33:56.710883"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 197,
     "fields": {
-      "id": "197",
-      "created": "2025-06-09 13:33:56.713135",
-      "modified": "2025-06-09 13:33:56.713155",
-      "logo": "",
-      "safa_id": "41TQA",
       "name": "SAFA UPHONGOLO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "29"
+      "logo": "",
+      "safa_id": "41TQA",
+      "region": 29,
+      "association": 4,
+      "created": "2025-06-09 13:33:56.713135",
+      "modified": "2025-06-09 13:33:56.713155"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 198,
     "fields": {
-      "id": "198",
-      "created": "2025-06-09 13:40:21.522147",
-      "modified": "2025-06-09 13:40:21.522187",
-      "logo": "",
-      "safa_id": "5GK9A",
       "name": "SAFA AGANANG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "30"
+      "logo": "",
+      "safa_id": "5GK9A",
+      "region": 30,
+      "association": 4,
+      "created": "2025-06-09 13:40:21.522147",
+      "modified": "2025-06-09 13:40:21.522187"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 199,
     "fields": {
-      "id": "199",
-      "created": "2025-06-09 13:40:21.525921",
-      "modified": "2025-06-09 13:40:21.525953",
-      "logo": "",
-      "safa_id": "SHPUQ",
       "name": "SAFA BLOUBERG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "30"
+      "logo": "",
+      "safa_id": "SHPUQ",
+      "region": 30,
+      "association": 4,
+      "created": "2025-06-09 13:40:21.525921",
+      "modified": "2025-06-09 13:40:21.525953"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 200,
     "fields": {
-      "id": "200",
-      "created": "2025-06-09 13:40:21.528331",
-      "modified": "2025-06-09 13:40:21.528354",
-      "logo": "",
-      "safa_id": "85QFL",
       "name": "SAFA LEPELLE-NKUMPI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "30"
+      "logo": "",
+      "safa_id": "85QFL",
+      "region": 30,
+      "association": 4,
+      "created": "2025-06-09 13:40:21.528331",
+      "modified": "2025-06-09 13:40:21.528354"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 201,
     "fields": {
-      "id": "201",
-      "created": "2025-06-09 13:40:21.530540",
-      "modified": "2025-06-09 13:40:21.530562",
-      "logo": "",
-      "safa_id": "VPI1Q",
       "name": "SAFA MOLEMOLE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "30"
+      "logo": "",
+      "safa_id": "VPI1Q",
+      "region": 30,
+      "association": 4,
+      "created": "2025-06-09 13:40:21.530540",
+      "modified": "2025-06-09 13:40:21.530562"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 202,
     "fields": {
-      "id": "202",
-      "created": "2025-06-09 13:40:21.532793",
-      "modified": "2025-06-09 13:40:21.532813",
-      "logo": "",
-      "safa_id": "YIJAE",
       "name": "SAFA POLOKWANE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "30"
+      "logo": "",
+      "safa_id": "YIJAE",
+      "region": 30,
+      "association": 4,
+      "created": "2025-06-09 13:40:21.532793",
+      "modified": "2025-06-09 13:40:21.532813"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 203,
     "fields": {
-      "id": "203",
-      "created": "2025-06-09 13:41:10.797679",
-      "modified": "2025-06-09 13:41:10.797737",
-      "logo": "",
-      "safa_id": "M3A8G",
       "name": "SAFA BA-PHALABORWA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "31"
+      "logo": "",
+      "safa_id": "M3A8G",
+      "region": 31,
+      "association": 4,
+      "created": "2025-06-09 13:41:10.797679",
+      "modified": "2025-06-09 13:41:10.797737"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 204,
     "fields": {
-      "id": "204",
-      "created": "2025-06-09 13:41:10.802267",
-      "modified": "2025-06-09 13:41:10.802306",
-      "logo": "",
-      "safa_id": "93IB2",
       "name": "SAFA GREATER GIYANE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "31"
+      "logo": "",
+      "safa_id": "93IB2",
+      "region": 31,
+      "association": 4,
+      "created": "2025-06-09 13:41:10.802267",
+      "modified": "2025-06-09 13:41:10.802306"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 205,
     "fields": {
-      "id": "205",
-      "created": "2025-06-09 13:41:10.806162",
-      "modified": "2025-06-09 13:41:10.806197",
-      "logo": "",
-      "safa_id": "7BZWW",
       "name": "SAFA GREATER LETABA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "31"
+      "logo": "",
+      "safa_id": "7BZWW",
+      "region": 31,
+      "association": 4,
+      "created": "2025-06-09 13:41:10.806162",
+      "modified": "2025-06-09 13:41:10.806197"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 206,
     "fields": {
-      "id": "206",
-      "created": "2025-06-09 13:41:10.811716",
-      "modified": "2025-06-09 13:41:10.811760",
-      "logo": "",
-      "safa_id": "TDWWW",
       "name": "SAFA GREATER TZANEEN LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "31"
+      "logo": "",
+      "safa_id": "TDWWW",
+      "region": 31,
+      "association": 4,
+      "created": "2025-06-09 13:41:10.811716",
+      "modified": "2025-06-09 13:41:10.811760"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 207,
     "fields": {
-      "id": "207",
-      "created": "2025-06-09 13:41:10.815771",
-      "modified": "2025-06-09 13:41:10.815804",
-      "logo": "",
-      "safa_id": "V3ZE5",
       "name": "SAFA MARULENG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "31"
+      "logo": "",
+      "safa_id": "V3ZE5",
+      "region": 31,
+      "association": 4,
+      "created": "2025-06-09 13:41:10.815771",
+      "modified": "2025-06-09 13:41:10.815804"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 208,
     "fields": {
-      "id": "208",
-      "created": "2025-06-09 13:41:54.931785",
-      "modified": "2025-06-09 13:41:54.931828",
-      "logo": "",
-      "safa_id": "RNTGA",
       "name": "SAFA ELIAS MOTSOALEDI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "32"
+      "logo": "",
+      "safa_id": "RNTGA",
+      "region": 32,
+      "association": 4,
+      "created": "2025-06-09 13:41:54.931785",
+      "modified": "2025-06-09 13:41:54.931828"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 209,
     "fields": {
-      "id": "209",
-      "created": "2025-06-09 13:41:54.935029",
-      "modified": "2025-06-09 13:41:54.935057",
-      "logo": "",
-      "safa_id": "9NYE2",
       "name": "SAFA FETAKGOMO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "32"
+      "logo": "",
+      "safa_id": "9NYE2",
+      "region": 32,
+      "association": 4,
+      "created": "2025-06-09 13:41:54.935029",
+      "modified": "2025-06-09 13:41:54.935057"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 210,
     "fields": {
-      "id": "210",
-      "created": "2025-06-09 13:41:54.937541",
-      "modified": "2025-06-09 13:41:54.937566",
-      "logo": "",
-      "safa_id": "1HFMZ",
       "name": "SAFA GREATER MARBLE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "32"
+      "logo": "",
+      "safa_id": "1HFMZ",
+      "region": 32,
+      "association": 4,
+      "created": "2025-06-09 13:41:54.937541",
+      "modified": "2025-06-09 13:41:54.937566"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 211,
     "fields": {
-      "id": "211",
-      "created": "2025-06-09 13:41:54.940006",
-      "modified": "2025-06-09 13:41:54.940029",
-      "logo": "",
-      "safa_id": "XDYR7",
       "name": "SAFA GREATER TUBATSE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "32"
+      "logo": "",
+      "safa_id": "XDYR7",
+      "region": 32,
+      "association": 4,
+      "created": "2025-06-09 13:41:54.940006",
+      "modified": "2025-06-09 13:41:54.940029"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 212,
     "fields": {
-      "id": "212",
-      "created": "2025-06-09 13:41:54.942747",
-      "modified": "2025-06-09 13:41:54.942775",
-      "logo": "",
-      "safa_id": "GFO3E",
       "name": "SAFA MAKHUDUTHAMAGA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "32"
+      "logo": "",
+      "safa_id": "GFO3E",
+      "region": 32,
+      "association": 4,
+      "created": "2025-06-09 13:41:54.942747",
+      "modified": "2025-06-09 13:41:54.942775"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 213,
     "fields": {
-      "id": "213",
-      "created": "2025-06-09 13:42:49.621432",
-      "modified": "2025-06-09 13:42:49.621521",
-      "logo": "",
-      "safa_id": "2MFJ0",
       "name": "SAFA MAKHADO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "33"
+      "logo": "",
+      "safa_id": "2MFJ0",
+      "region": 33,
+      "association": 4,
+      "created": "2025-06-09 13:42:49.621432",
+      "modified": "2025-06-09 13:42:49.621521"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 214,
     "fields": {
-      "id": "214",
-      "created": "2025-06-09 13:42:49.627138",
-      "modified": "2025-06-09 13:42:49.627187",
-      "logo": "",
-      "safa_id": "YCOII",
       "name": "SAFA MUSINA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "33"
+      "logo": "",
+      "safa_id": "YCOII",
+      "region": 33,
+      "association": 4,
+      "created": "2025-06-09 13:42:49.627138",
+      "modified": "2025-06-09 13:42:49.627187"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 215,
     "fields": {
-      "id": "215",
-      "created": "2025-06-09 13:42:49.631668",
-      "modified": "2025-06-09 13:42:49.631766",
-      "logo": "",
-      "safa_id": "HOSE3",
       "name": "SAFA MUTALE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "33"
+      "logo": "",
+      "safa_id": "HOSE3",
+      "region": 33,
+      "association": 4,
+      "created": "2025-06-09 13:42:49.631668",
+      "modified": "2025-06-09 13:42:49.631766"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 216,
     "fields": {
-      "id": "216",
-      "created": "2025-06-09 13:42:49.635942",
-      "modified": "2025-06-09 13:42:49.635982",
-      "logo": "",
-      "safa_id": "T02Q1",
       "name": "SAFA THULAMELA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "33"
+      "logo": "",
+      "safa_id": "T02Q1",
+      "region": 33,
+      "association": 4,
+      "created": "2025-06-09 13:42:49.635942",
+      "modified": "2025-06-09 13:42:49.635982"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 217,
     "fields": {
-      "id": "217",
-      "created": "2025-06-09 13:43:42.426187",
-      "modified": "2025-06-09 13:43:42.426224",
-      "logo": "",
-      "safa_id": "9O3RH",
       "name": "SAFA BELA-BELA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "34"
+      "logo": "",
+      "safa_id": "9O3RH",
+      "region": 34,
+      "association": 4,
+      "created": "2025-06-09 13:43:42.426187",
+      "modified": "2025-06-09 13:43:42.426224"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 218,
     "fields": {
-      "id": "218",
-      "created": "2025-06-09 13:43:42.429170",
-      "modified": "2025-06-09 13:43:42.429196",
-      "logo": "",
-      "safa_id": "PB14M",
       "name": "SAFA LEPHALALE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "34"
+      "logo": "",
+      "safa_id": "PB14M",
+      "region": 34,
+      "association": 4,
+      "created": "2025-06-09 13:43:42.429170",
+      "modified": "2025-06-09 13:43:42.429196"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 219,
     "fields": {
-      "id": "219",
-      "created": "2025-06-09 13:43:42.431755",
-      "modified": "2025-06-09 13:43:42.431779",
-      "logo": "",
-      "safa_id": "CXE10",
       "name": "SAFA MODIMOLLE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "34"
+      "logo": "",
+      "safa_id": "CXE10",
+      "region": 34,
+      "association": 4,
+      "created": "2025-06-09 13:43:42.431755",
+      "modified": "2025-06-09 13:43:42.431779"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 220,
     "fields": {
-      "id": "220",
-      "created": "2025-06-09 13:43:42.433939",
-      "modified": "2025-06-09 13:43:42.433960",
-      "logo": "",
-      "safa_id": "W4WKY",
       "name": "SAFA MOGALAKWENA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "34"
+      "logo": "",
+      "safa_id": "W4WKY",
+      "region": 34,
+      "association": 4,
+      "created": "2025-06-09 13:43:42.433939",
+      "modified": "2025-06-09 13:43:42.433960"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 221,
     "fields": {
-      "id": "221",
-      "created": "2025-06-09 13:43:42.436831",
-      "modified": "2025-06-09 13:43:42.436863",
-      "logo": "",
-      "safa_id": "1ZJWT",
       "name": "SAFA MOOKGOPHONG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "34"
+      "logo": "",
+      "safa_id": "1ZJWT",
+      "region": 34,
+      "association": 4,
+      "created": "2025-06-09 13:43:42.436831",
+      "modified": "2025-06-09 13:43:42.436863"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 222,
     "fields": {
-      "id": "222",
-      "created": "2025-06-09 13:43:42.439664",
-      "modified": "2025-06-09 13:43:42.439692",
-      "logo": "",
-      "safa_id": "HMXVL",
       "name": "SAFA THABAZIMBI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "34"
+      "logo": "",
+      "safa_id": "HMXVL",
+      "region": 34,
+      "association": 4,
+      "created": "2025-06-09 13:43:42.439664",
+      "modified": "2025-06-09 13:43:42.439692"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 223,
     "fields": {
-      "id": "223",
-      "created": "2025-06-09 13:50:17.146816",
-      "modified": "2025-06-09 13:50:17.146850",
-      "logo": "",
-      "safa_id": "4JDZF",
       "name": "SAFA BUSHBUCKRIDGE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "35"
+      "logo": "",
+      "safa_id": "4JDZF",
+      "region": 35,
+      "association": 4,
+      "created": "2025-06-09 13:50:17.146816",
+      "modified": "2025-06-09 13:50:17.146850"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 224,
     "fields": {
-      "id": "224",
-      "created": "2025-06-09 13:50:17.149953",
-      "modified": "2025-06-09 13:50:17.149984",
-      "logo": "",
-      "safa_id": "8BAFO",
       "name": "SAFA MBOMBELA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "35"
+      "logo": "",
+      "safa_id": "8BAFO",
+      "region": 35,
+      "association": 4,
+      "created": "2025-06-09 13:50:17.149953",
+      "modified": "2025-06-09 13:50:17.149984"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 225,
     "fields": {
-      "id": "225",
-      "created": "2025-06-09 13:50:17.152781",
-      "modified": "2025-06-09 13:50:17.152812",
-      "logo": "",
-      "safa_id": "D407T",
       "name": "SAFA NKOMAZI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "35"
+      "logo": "",
+      "safa_id": "D407T",
+      "region": 35,
+      "association": 4,
+      "created": "2025-06-09 13:50:17.152781",
+      "modified": "2025-06-09 13:50:17.152812"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 226,
     "fields": {
-      "id": "226",
-      "created": "2025-06-09 13:50:17.155244",
-      "modified": "2025-06-09 13:50:17.155266",
-      "logo": "",
-      "safa_id": "J4NEE",
       "name": "SAFA THABA CHWEU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "35"
+      "logo": "",
+      "safa_id": "J4NEE",
+      "region": 35,
+      "association": 4,
+      "created": "2025-06-09 13:50:17.155244",
+      "modified": "2025-06-09 13:50:17.155266"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 227,
     "fields": {
-      "id": "227",
-      "created": "2025-06-09 13:50:17.157598",
-      "modified": "2025-06-09 13:50:17.157623",
-      "logo": "",
-      "safa_id": "NF2FX",
       "name": "SAFA UMJINDI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "35"
+      "logo": "",
+      "safa_id": "NF2FX",
+      "region": 35,
+      "association": 4,
+      "created": "2025-06-09 13:50:17.157598",
+      "modified": "2025-06-09 13:50:17.157623"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 228,
     "fields": {
-      "id": "228",
-      "created": "2025-06-09 13:51:23.635689",
-      "modified": "2025-06-09 13:51:23.635726",
-      "logo": "",
-      "safa_id": "ZWWOX",
       "name": "SAFA ALBERT LUTHULI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "36"
+      "logo": "",
+      "safa_id": "ZWWOX",
+      "region": 36,
+      "association": 4,
+      "created": "2025-06-09 13:51:23.635689",
+      "modified": "2025-06-09 13:51:23.635726"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 229,
     "fields": {
-      "id": "229",
-      "created": "2025-06-09 13:51:23.638565",
-      "modified": "2025-06-09 13:51:23.638604",
-      "logo": "",
-      "safa_id": "A7R0G",
       "name": "SAFA DIPALESENG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "36"
+      "logo": "",
+      "safa_id": "A7R0G",
+      "region": 36,
+      "association": 4,
+      "created": "2025-06-09 13:51:23.638565",
+      "modified": "2025-06-09 13:51:23.638604"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 230,
     "fields": {
-      "id": "230",
-      "created": "2025-06-09 13:51:23.640765",
-      "modified": "2025-06-09 13:51:23.640785",
-      "logo": "",
-      "safa_id": "UR2XS",
       "name": "SAFA GOVAN MBEKI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "36"
+      "logo": "",
+      "safa_id": "UR2XS",
+      "region": 36,
+      "association": 4,
+      "created": "2025-06-09 13:51:23.640765",
+      "modified": "2025-06-09 13:51:23.640785"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 231,
     "fields": {
-      "id": "231",
-      "created": "2025-06-09 13:51:23.642927",
-      "modified": "2025-06-09 13:51:23.642948",
-      "logo": "",
-      "safa_id": "NQ8YG",
       "name": "SAFA LEKWA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "36"
+      "logo": "",
+      "safa_id": "NQ8YG",
+      "region": 36,
+      "association": 4,
+      "created": "2025-06-09 13:51:23.642927",
+      "modified": "2025-06-09 13:51:23.642948"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 232,
     "fields": {
-      "id": "232",
-      "created": "2025-06-09 13:51:23.645104",
-      "modified": "2025-06-09 13:51:23.645123",
-      "logo": "",
-      "safa_id": "R3XYA",
       "name": "SAFA MKHONDO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "36"
+      "logo": "",
+      "safa_id": "R3XYA",
+      "region": 36,
+      "association": 4,
+      "created": "2025-06-09 13:51:23.645104",
+      "modified": "2025-06-09 13:51:23.645123"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 233,
     "fields": {
-      "id": "233",
-      "created": "2025-06-09 13:51:23.647194",
-      "modified": "2025-06-09 13:51:23.647213",
-      "logo": "",
-      "safa_id": "2CVGG",
       "name": "SAFA MSUKWALINGWA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "36"
+      "logo": "",
+      "safa_id": "2CVGG",
+      "region": 36,
+      "association": 4,
+      "created": "2025-06-09 13:51:23.647194",
+      "modified": "2025-06-09 13:51:23.647213"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 234,
     "fields": {
-      "id": "234",
-      "created": "2025-06-09 13:51:23.649423",
-      "modified": "2025-06-09 13:51:23.649443",
-      "logo": "",
-      "safa_id": "50UDR",
       "name": "SAFA PIXLEY KA SEME LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "36"
+      "logo": "",
+      "safa_id": "50UDR",
+      "region": 36,
+      "association": 4,
+      "created": "2025-06-09 13:51:23.649423",
+      "modified": "2025-06-09 13:51:23.649443"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 235,
     "fields": {
-      "id": "235",
-      "created": "2025-06-09 13:55:45.982848",
-      "modified": "2025-06-09 13:55:45.982884",
-      "logo": "",
-      "safa_id": "Q17EM",
       "name": "SAFA DR JS MOROKA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "37"
+      "logo": "",
+      "safa_id": "Q17EM",
+      "region": 37,
+      "association": 4,
+      "created": "2025-06-09 13:55:45.982848",
+      "modified": "2025-06-09 13:55:45.982884"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 236,
     "fields": {
-      "id": "236",
-      "created": "2025-06-09 13:55:45.985725",
-      "modified": "2025-06-09 13:55:45.985749",
-      "logo": "",
-      "safa_id": "5KPFI",
       "name": "SAFA EMAKHAZENI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "37"
+      "logo": "",
+      "safa_id": "5KPFI",
+      "region": 37,
+      "association": 4,
+      "created": "2025-06-09 13:55:45.985725",
+      "modified": "2025-06-09 13:55:45.985749"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 237,
     "fields": {
-      "id": "237",
-      "created": "2025-06-09 13:55:45.987900",
-      "modified": "2025-06-09 13:55:45.987921",
-      "logo": "",
-      "safa_id": "GUGP6",
       "name": "SAFA EMALAHLENI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "37"
+      "logo": "",
+      "safa_id": "GUGP6",
+      "region": 37,
+      "association": 4,
+      "created": "2025-06-09 13:55:45.987900",
+      "modified": "2025-06-09 13:55:45.987921"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 238,
     "fields": {
-      "id": "238",
-      "created": "2025-06-09 13:55:45.990017",
-      "modified": "2025-06-09 13:55:45.990037",
-      "logo": "",
-      "safa_id": "YVE9O",
       "name": "SAFA STEVE TSHWETE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "37"
+      "logo": "",
+      "safa_id": "YVE9O",
+      "region": 37,
+      "association": 4,
+      "created": "2025-06-09 13:55:45.990017",
+      "modified": "2025-06-09 13:55:45.990037"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 239,
     "fields": {
-      "id": "239",
-      "created": "2025-06-09 13:55:45.992231",
-      "modified": "2025-06-09 13:55:45.992250",
-      "logo": "",
-      "safa_id": "3RV88",
       "name": "SAFA THEMBISILE HANI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "37"
+      "logo": "",
+      "safa_id": "3RV88",
+      "region": 37,
+      "association": 4,
+      "created": "2025-06-09 13:55:45.992231",
+      "modified": "2025-06-09 13:55:45.992250"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 240,
     "fields": {
-      "id": "240",
-      "created": "2025-06-09 13:55:45.995455",
-      "modified": "2025-06-09 13:55:45.995496",
-      "logo": "",
-      "safa_id": "2X9DQ",
       "name": "SAFA VICTOR KHANYE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "37"
+      "logo": "",
+      "safa_id": "2X9DQ",
+      "region": 37,
+      "association": 4,
+      "created": "2025-06-09 13:55:45.995455",
+      "modified": "2025-06-09 13:55:45.995496"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 241,
     "fields": {
-      "id": "241",
-      "created": "2025-06-09 14:00:03.084884",
-      "modified": "2025-06-09 14:00:03.084941",
-      "logo": "",
-      "safa_id": "HZMFO",
       "name": "SAFA KGETLENG RIVER LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "38"
+      "logo": "",
+      "safa_id": "HZMFO",
+      "region": 38,
+      "association": 4,
+      "created": "2025-06-09 14:00:03.084884",
+      "modified": "2025-06-09 14:00:03.084941"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 242,
     "fields": {
-      "id": "242",
-      "created": "2025-06-09 14:00:03.089556",
-      "modified": "2025-06-09 14:00:03.089603",
-      "logo": "",
-      "safa_id": "OTXUY",
       "name": "SAFA MADIBENG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "38"
+      "logo": "",
+      "safa_id": "OTXUY",
+      "region": 38,
+      "association": 4,
+      "created": "2025-06-09 14:00:03.089556",
+      "modified": "2025-06-09 14:00:03.089603"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 243,
     "fields": {
-      "id": "243",
-      "created": "2025-06-09 14:00:03.094974",
-      "modified": "2025-06-09 14:00:03.095022",
-      "logo": "",
-      "safa_id": "L0I4X",
       "name": "SAFA MORETELE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "38"
+      "logo": "",
+      "safa_id": "L0I4X",
+      "region": 38,
+      "association": 4,
+      "created": "2025-06-09 14:00:03.094974",
+      "modified": "2025-06-09 14:00:03.095022"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 244,
     "fields": {
-      "id": "244",
-      "created": "2025-06-09 14:00:03.098754",
-      "modified": "2025-06-09 14:00:03.098798",
-      "logo": "",
-      "safa_id": "9KC6K",
       "name": "SAFA MOSES KOTANE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "38"
+      "logo": "",
+      "safa_id": "9KC6K",
+      "region": 38,
+      "association": 4,
+      "created": "2025-06-09 14:00:03.098754",
+      "modified": "2025-06-09 14:00:03.098798"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 245,
     "fields": {
-      "id": "245",
-      "created": "2025-06-09 14:00:03.102621",
-      "modified": "2025-06-09 14:00:03.102701",
-      "logo": "",
-      "safa_id": "LP4XX",
       "name": "SAFA RUSTENBURG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "38"
+      "logo": "",
+      "safa_id": "LP4XX",
+      "region": 38,
+      "association": 4,
+      "created": "2025-06-09 14:00:03.102621",
+      "modified": "2025-06-09 14:00:03.102701"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 246,
     "fields": {
-      "id": "246",
-      "created": "2025-06-09 14:00:56.878901",
-      "modified": "2025-06-09 14:00:56.878936",
-      "logo": "",
-      "safa_id": "VM3KT",
       "name": "SAFA MAQUASSI-HILLS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "39"
+      "logo": "",
+      "safa_id": "VM3KT",
+      "region": 39,
+      "association": 4,
+      "created": "2025-06-09 14:00:56.878901",
+      "modified": "2025-06-09 14:00:56.878936"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 247,
     "fields": {
-      "id": "247",
-      "created": "2025-06-09 14:00:56.881764",
-      "modified": "2025-06-09 14:00:56.881787",
-      "logo": "",
-      "safa_id": "9FBEF",
       "name": "SAFA MATLOSANA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "39"
+      "logo": "",
+      "safa_id": "9FBEF",
+      "region": 39,
+      "association": 4,
+      "created": "2025-06-09 14:00:56.881764",
+      "modified": "2025-06-09 14:00:56.881787"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 248,
     "fields": {
-      "id": "248",
-      "created": "2025-06-09 14:00:56.883926",
-      "modified": "2025-06-09 14:00:56.883946",
-      "logo": "",
-      "safa_id": "AE97A",
       "name": "SAFA POTCHEFSTROOM LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "39"
+      "logo": "",
+      "safa_id": "AE97A",
+      "region": 39,
+      "association": 4,
+      "created": "2025-06-09 14:00:56.883926",
+      "modified": "2025-06-09 14:00:56.883946"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 249,
     "fields": {
-      "id": "249",
-      "created": "2025-06-09 14:00:56.886033",
-      "modified": "2025-06-09 14:00:56.886053",
-      "logo": "",
-      "safa_id": "X02MQ",
       "name": "SAFA VENTERSDORP LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "39"
+      "logo": "",
+      "safa_id": "X02MQ",
+      "region": 39,
+      "association": 4,
+      "created": "2025-06-09 14:00:56.886033",
+      "modified": "2025-06-09 14:00:56.886053"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 250,
     "fields": {
-      "id": "250",
-      "created": "2025-06-09 14:01:48.594287",
-      "modified": "2025-06-09 14:01:48.594323",
-      "logo": "",
-      "safa_id": "0Y6NQ",
       "name": "SAFA GREATER TAUNG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "40"
+      "logo": "",
+      "safa_id": "0Y6NQ",
+      "region": 40,
+      "association": 4,
+      "created": "2025-06-09 14:01:48.594287",
+      "modified": "2025-06-09 14:01:48.594323"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 251,
     "fields": {
-      "id": "251",
-      "created": "2025-06-09 14:01:48.597165",
-      "modified": "2025-06-09 14:01:48.597187",
-      "logo": "",
-      "safa_id": "4ODBV",
       "name": "SAFA KAGISANO MOLOPO LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "40"
+      "logo": "",
+      "safa_id": "4ODBV",
+      "region": 40,
+      "association": 4,
+      "created": "2025-06-09 14:01:48.597165",
+      "modified": "2025-06-09 14:01:48.597187"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 252,
     "fields": {
-      "id": "252",
-      "created": "2025-06-09 14:01:48.599337",
-      "modified": "2025-06-09 14:01:48.599369",
-      "logo": "",
-      "safa_id": "P4QRG",
       "name": "SAFA LEKWA-TEEMANE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "40"
+      "logo": "",
+      "safa_id": "P4QRG",
+      "region": 40,
+      "association": 4,
+      "created": "2025-06-09 14:01:48.599337",
+      "modified": "2025-06-09 14:01:48.599369"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 253,
     "fields": {
-      "id": "253",
-      "created": "2025-06-09 14:01:48.601509",
-      "modified": "2025-06-09 14:01:48.601529",
-      "logo": "",
-      "safa_id": "7AB4Y",
       "name": "SAFA MAMUSA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "40"
+      "logo": "",
+      "safa_id": "7AB4Y",
+      "region": 40,
+      "association": 4,
+      "created": "2025-06-09 14:01:48.601509",
+      "modified": "2025-06-09 14:01:48.601529"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 254,
     "fields": {
-      "id": "254",
-      "created": "2025-06-09 14:01:48.603792",
-      "modified": "2025-06-09 14:01:48.603812",
-      "logo": "",
-      "safa_id": "JI7XX",
       "name": "SAFA NALEDI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "40"
+      "logo": "",
+      "safa_id": "JI7XX",
+      "region": 40,
+      "association": 4,
+      "created": "2025-06-09 14:01:48.603792",
+      "modified": "2025-06-09 14:01:48.603812"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 255,
     "fields": {
-      "id": "255",
-      "created": "2025-06-09 14:02:37.181332",
-      "modified": "2025-06-09 14:02:37.181392",
-      "logo": "",
-      "safa_id": "WU4RX",
       "name": "SAFA DITSOBOTLA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "41"
+      "logo": "",
+      "safa_id": "WU4RX",
+      "region": 41,
+      "association": 4,
+      "created": "2025-06-09 14:02:37.181332",
+      "modified": "2025-06-09 14:02:37.181392"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 256,
     "fields": {
-      "id": "256",
-      "created": "2025-06-09 14:02:37.186386",
-      "modified": "2025-06-09 14:02:37.186443",
-      "logo": "",
-      "safa_id": "W6COQ",
       "name": "SAFA MAFIKENG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "41"
+      "logo": "",
+      "safa_id": "W6COQ",
+      "region": 41,
+      "association": 4,
+      "created": "2025-06-09 14:02:37.186386",
+      "modified": "2025-06-09 14:02:37.186443"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 257,
     "fields": {
-      "id": "257",
-      "created": "2025-06-09 14:02:37.189360",
-      "modified": "2025-06-09 14:02:37.189381",
-      "logo": "",
-      "safa_id": "6IU2I",
       "name": "SAFA RAMOTSHERE MOILOA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "41"
+      "logo": "",
+      "safa_id": "6IU2I",
+      "region": 41,
+      "association": 4,
+      "created": "2025-06-09 14:02:37.189360",
+      "modified": "2025-06-09 14:02:37.189381"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 258,
     "fields": {
-      "id": "258",
-      "created": "2025-06-09 14:02:37.191810",
-      "modified": "2025-06-09 14:02:37.191848",
-      "logo": "",
-      "safa_id": "GWNP6",
       "name": "SAFA RATLOU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "41"
+      "logo": "",
+      "safa_id": "GWNP6",
+      "region": 41,
+      "association": 4,
+      "created": "2025-06-09 14:02:37.191810",
+      "modified": "2025-06-09 14:02:37.191848"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 259,
     "fields": {
-      "id": "259",
-      "created": "2025-06-09 14:02:37.196136",
-      "modified": "2025-06-09 14:02:37.196174",
-      "logo": "",
-      "safa_id": "SYTJ4",
       "name": "SAFA TSWAING LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "41"
+      "logo": "",
+      "safa_id": "SYTJ4",
+      "region": 41,
+      "association": 4,
+      "created": "2025-06-09 14:02:37.196136",
+      "modified": "2025-06-09 14:02:37.196174"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 260,
     "fields": {
-      "id": "260",
-      "created": "2025-06-09 14:05:07.295451",
-      "modified": "2025-06-09 14:05:07.295487",
-      "logo": "",
-      "safa_id": "1NTCB",
       "name": "SAFA DIKGATLONG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "42"
+      "logo": "",
+      "safa_id": "1NTCB",
+      "region": 42,
+      "association": 4,
+      "created": "2025-06-09 14:05:07.295451",
+      "modified": "2025-06-09 14:05:07.295487"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 261,
     "fields": {
-      "id": "261",
-      "created": "2025-06-09 14:05:07.298392",
-      "modified": "2025-06-09 14:05:07.298417",
-      "logo": "",
-      "safa_id": "MJCE4",
       "name": "SAFA MAGARENG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "42"
+      "logo": "",
+      "safa_id": "MJCE4",
+      "region": 42,
+      "association": 4,
+      "created": "2025-06-09 14:05:07.298392",
+      "modified": "2025-06-09 14:05:07.298417"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 262,
     "fields": {
-      "id": "262",
-      "created": "2025-06-09 14:05:07.300705",
-      "modified": "2025-06-09 14:05:07.300726",
-      "logo": "",
-      "safa_id": "PDRRZ",
       "name": "SAFA PHOKWANE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "42"
+      "logo": "",
+      "safa_id": "PDRRZ",
+      "region": 42,
+      "association": 4,
+      "created": "2025-06-09 14:05:07.300705",
+      "modified": "2025-06-09 14:05:07.300726"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 263,
     "fields": {
-      "id": "263",
-      "created": "2025-06-09 14:05:07.302846",
-      "modified": "2025-06-09 14:05:07.302866",
-      "logo": "",
-      "safa_id": "NJRBF",
       "name": "SAFA SOL PLAATJIE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "42"
+      "logo": "",
+      "safa_id": "NJRBF",
+      "region": 42,
+      "association": 4,
+      "created": "2025-06-09 14:05:07.302846",
+      "modified": "2025-06-09 14:05:07.302866"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 264,
     "fields": {
-      "id": "264",
-      "created": "2025-06-09 14:06:09.054378",
-      "modified": "2025-06-09 14:06:09.054429",
-      "logo": "",
-      "safa_id": "N1KZP",
       "name": "SAFA GAMAGARA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "43"
+      "logo": "",
+      "safa_id": "N1KZP",
+      "region": 43,
+      "association": 4,
+      "created": "2025-06-09 14:06:09.054378",
+      "modified": "2025-06-09 14:06:09.054429"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 265,
     "fields": {
-      "id": "265",
-      "created": "2025-06-09 14:06:09.057293",
-      "modified": "2025-06-09 14:06:09.057317",
-      "logo": "",
-      "safa_id": "X42XF",
       "name": "SAFA GA-SEGONYANA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "43"
+      "logo": "",
+      "safa_id": "X42XF",
+      "region": 43,
+      "association": 4,
+      "created": "2025-06-09 14:06:09.057293",
+      "modified": "2025-06-09 14:06:09.057317"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 266,
     "fields": {
-      "id": "266",
-      "created": "2025-06-09 14:06:09.059479",
-      "modified": "2025-06-09 14:06:09.059500",
-      "logo": "",
-      "safa_id": "5YNCL",
       "name": "SAFA JOE MOROLONG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "43"
+      "logo": "",
+      "safa_id": "5YNCL",
+      "region": 43,
+      "association": 4,
+      "created": "2025-06-09 14:06:09.059479",
+      "modified": "2025-06-09 14:06:09.059500"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 267,
     "fields": {
-      "id": "267",
-      "created": "2025-06-09 14:07:00.885566",
-      "modified": "2025-06-09 14:07:00.885603",
-      "logo": "",
-      "safa_id": "Q9CK6",
       "name": "SAFA HANTAM LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "44"
+      "logo": "",
+      "safa_id": "Q9CK6",
+      "region": 44,
+      "association": 4,
+      "created": "2025-06-09 14:07:00.885566",
+      "modified": "2025-06-09 14:07:00.885603"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 268,
     "fields": {
-      "id": "268",
-      "created": "2025-06-09 14:07:00.888411",
-      "modified": "2025-06-09 14:07:00.888434",
-      "logo": "",
-      "safa_id": "4T082",
       "name": "SAFA KAMIESBERG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "44"
+      "logo": "",
+      "safa_id": "4T082",
+      "region": 44,
+      "association": 4,
+      "created": "2025-06-09 14:07:00.888411",
+      "modified": "2025-06-09 14:07:00.888434"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 269,
     "fields": {
-      "id": "269",
-      "created": "2025-06-09 14:07:00.890576",
-      "modified": "2025-06-09 14:07:00.890596",
-      "logo": "",
-      "safa_id": "HE17F",
       "name": "SAFA KAROO HOOGLAND LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "44"
+      "logo": "",
+      "safa_id": "HE17F",
+      "region": 44,
+      "association": 4,
+      "created": "2025-06-09 14:07:00.890576",
+      "modified": "2025-06-09 14:07:00.890596"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 270,
     "fields": {
-      "id": "270",
-      "created": "2025-06-09 14:07:00.892712",
-      "modified": "2025-06-09 14:07:00.892732",
-      "logo": "",
-      "safa_id": "G9QM6",
       "name": "SAFA KHAI-MA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "44"
+      "logo": "",
+      "safa_id": "G9QM6",
+      "region": 44,
+      "association": 4,
+      "created": "2025-06-09 14:07:00.892712",
+      "modified": "2025-06-09 14:07:00.892732"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 271,
     "fields": {
-      "id": "271",
-      "created": "2025-06-09 14:07:00.894898",
-      "modified": "2025-06-09 14:07:00.894918",
-      "logo": "",
-      "safa_id": "44SP1",
       "name": "SAFA NAMA KHOI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "44"
+      "logo": "",
+      "safa_id": "44SP1",
+      "region": 44,
+      "association": 4,
+      "created": "2025-06-09 14:07:00.894898",
+      "modified": "2025-06-09 14:07:00.894918"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 272,
     "fields": {
-      "id": "272",
-      "created": "2025-06-09 14:07:00.897101",
-      "modified": "2025-06-09 14:07:00.897122",
-      "logo": "",
-      "safa_id": "CX0TS",
       "name": "SAFA RICHTERSVELD LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "44"
+      "logo": "",
+      "safa_id": "CX0TS",
+      "region": 44,
+      "association": 4,
+      "created": "2025-06-09 14:07:00.897101",
+      "modified": "2025-06-09 14:07:00.897122"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 273,
     "fields": {
-      "id": "273",
-      "created": "2025-06-09 14:07:53.870799",
-      "modified": "2025-06-09 14:07:53.870835",
-      "logo": "",
-      "safa_id": "656GF",
       "name": "SAFA EMTHANJENI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "45"
+      "logo": "",
+      "safa_id": "656GF",
+      "region": 45,
+      "association": 4,
+      "created": "2025-06-09 14:07:53.870799",
+      "modified": "2025-06-09 14:07:53.870835"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 274,
     "fields": {
-      "id": "274",
-      "created": "2025-06-09 14:07:53.873586",
-      "modified": "2025-06-09 14:07:53.873609",
-      "logo": "",
-      "safa_id": "QG3IX",
       "name": "SAFA KAREESBERG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "45"
+      "logo": "",
+      "safa_id": "QG3IX",
+      "region": 45,
+      "association": 4,
+      "created": "2025-06-09 14:07:53.873586",
+      "modified": "2025-06-09 14:07:53.873609"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 275,
     "fields": {
-      "id": "275",
-      "created": "2025-06-09 14:07:53.875800",
-      "modified": "2025-06-09 14:07:53.875820",
-      "logo": "",
-      "safa_id": "PMUO4",
       "name": "SAFA RENOSTERBERG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "45"
+      "logo": "",
+      "safa_id": "PMUO4",
+      "region": 45,
+      "association": 4,
+      "created": "2025-06-09 14:07:53.875800",
+      "modified": "2025-06-09 14:07:53.875820"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 276,
     "fields": {
-      "id": "276",
-      "created": "2025-06-09 14:07:53.878028",
-      "modified": "2025-06-09 14:07:53.878048",
-      "logo": "",
-      "safa_id": "9D7NF",
       "name": "SAFA SIYANCUMA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "45"
+      "logo": "",
+      "safa_id": "9D7NF",
+      "region": 45,
+      "association": 4,
+      "created": "2025-06-09 14:07:53.878028",
+      "modified": "2025-06-09 14:07:53.878048"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 277,
     "fields": {
-      "id": "277",
-      "created": "2025-06-09 14:07:53.880246",
-      "modified": "2025-06-09 14:07:53.880265",
-      "logo": "",
-      "safa_id": "AHOGJ",
       "name": "SAFA SIYATHEMBA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "45"
+      "logo": "",
+      "safa_id": "AHOGJ",
+      "region": 45,
+      "association": 4,
+      "created": "2025-06-09 14:07:53.880246",
+      "modified": "2025-06-09 14:07:53.880265"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 278,
     "fields": {
-      "id": "278",
-      "created": "2025-06-09 14:07:53.882366",
-      "modified": "2025-06-09 14:07:53.882387",
-      "logo": "",
-      "safa_id": "NR612",
       "name": "SAFA THEMBELIHLE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "45"
+      "logo": "",
+      "safa_id": "NR612",
+      "region": 45,
+      "association": 4,
+      "created": "2025-06-09 14:07:53.882366",
+      "modified": "2025-06-09 14:07:53.882387"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 279,
     "fields": {
-      "id": "279",
-      "created": "2025-06-09 14:07:53.884491",
-      "modified": "2025-06-09 14:07:53.884510",
-      "logo": "",
-      "safa_id": "3FNAA",
       "name": "SAFA UBUNTU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "45"
+      "logo": "",
+      "safa_id": "3FNAA",
+      "region": 45,
+      "association": 4,
+      "created": "2025-06-09 14:07:53.884491",
+      "modified": "2025-06-09 14:07:53.884510"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 280,
     "fields": {
-      "id": "280",
-      "created": "2025-06-09 14:07:53.886674",
-      "modified": "2025-06-09 14:07:53.886697",
-      "logo": "",
-      "safa_id": "8JUPS",
       "name": "SAFA UMSOBOMVU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "45"
+      "logo": "",
+      "safa_id": "8JUPS",
+      "region": 45,
+      "association": 4,
+      "created": "2025-06-09 14:07:53.886674",
+      "modified": "2025-06-09 14:07:53.886697"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 281,
     "fields": {
-      "id": "281",
-      "created": "2025-06-09 14:08:43.979748",
-      "modified": "2025-06-09 14:08:43.979783",
-      "logo": "",
-      "safa_id": "VSE13",
       "name": "SAFA KAI !GARIB LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "46"
+      "logo": "",
+      "safa_id": "VSE13",
+      "region": 46,
+      "association": 4,
+      "created": "2025-06-09 14:08:43.979748",
+      "modified": "2025-06-09 14:08:43.979783"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 282,
     "fields": {
-      "id": "282",
-      "created": "2025-06-09 14:08:43.982416",
-      "modified": "2025-06-09 14:08:43.982438",
-      "logo": "",
-      "safa_id": "R7YZQ",
       "name": "SAFA KGATELOPELE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "46"
+      "logo": "",
+      "safa_id": "R7YZQ",
+      "region": 46,
+      "association": 4,
+      "created": "2025-06-09 14:08:43.982416",
+      "modified": "2025-06-09 14:08:43.982438"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 283,
     "fields": {
-      "id": "283",
-      "created": "2025-06-09 14:08:43.984559",
-      "modified": "2025-06-09 14:08:43.984579",
-      "logo": "",
-      "safa_id": "9UF3V",
       "name": "SAFA KHARA HAIS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "46"
+      "logo": "",
+      "safa_id": "9UF3V",
+      "region": 46,
+      "association": 4,
+      "created": "2025-06-09 14:08:43.984559",
+      "modified": "2025-06-09 14:08:43.984579"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 284,
     "fields": {
-      "id": "284",
-      "created": "2025-06-09 14:08:43.986871",
-      "modified": "2025-06-09 14:08:43.986903",
-      "logo": "",
-      "safa_id": "XU93C",
       "name": "SAFA !KHEIS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "46"
+      "logo": "",
+      "safa_id": "XU93C",
+      "region": 46,
+      "association": 4,
+      "created": "2025-06-09 14:08:43.986871",
+      "modified": "2025-06-09 14:08:43.986903"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 285,
     "fields": {
-      "id": "285",
-      "created": "2025-06-09 14:08:43.990471",
-      "modified": "2025-06-09 14:08:43.990498",
-      "logo": "",
-      "safa_id": "6DTTX",
       "name": "SAFA MIER LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "46"
+      "logo": "",
+      "safa_id": "6DTTX",
+      "region": 46,
+      "association": 4,
+      "created": "2025-06-09 14:08:43.990471",
+      "modified": "2025-06-09 14:08:43.990498"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 286,
     "fields": {
-      "id": "286",
-      "created": "2025-06-09 14:08:43.992783",
-      "modified": "2025-06-09 14:08:43.992802",
-      "logo": "",
-      "safa_id": "4KDKA",
       "name": "SAFA TSANTSABANE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "46"
+      "logo": "",
+      "safa_id": "4KDKA",
+      "region": 46,
+      "association": 4,
+      "created": "2025-06-09 14:08:43.992783",
+      "modified": "2025-06-09 14:08:43.992802"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 287,
     "fields": {
-      "id": "287",
-      "created": "2025-06-09 14:13:29.331058",
-      "modified": "2025-06-09 14:13:29.331093",
-      "logo": "",
-      "safa_id": "RKO1W",
       "name": "SAFA ATHLONE HEIDEVELD LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "RKO1W",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.331058",
+      "modified": "2025-06-09 14:13:29.331093"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 288,
     "fields": {
-      "id": "288",
-      "created": "2025-06-09 14:13:29.334027",
-      "modified": "2025-06-09 14:13:29.334054",
-      "logo": "",
-      "safa_id": "H467N",
       "name": "SAFA ATLANTIS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "H467N",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.334027",
+      "modified": "2025-06-09 14:13:29.334054"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 289,
     "fields": {
-      "id": "289",
-      "created": "2025-06-09 14:13:29.336222",
-      "modified": "2025-06-09 14:13:29.336242",
-      "logo": "",
-      "safa_id": "KEQPZ",
       "name": "SAFA BLOEKOMBOS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "KEQPZ",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.336222",
+      "modified": "2025-06-09 14:13:29.336242"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 290,
     "fields": {
-      "id": "290",
-      "created": "2025-06-09 14:13:29.338321",
-      "modified": "2025-06-09 14:13:29.338341",
-      "logo": "",
-      "safa_id": "8RVH7",
       "name": "SAFA BLUEDOWNS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "8RVH7",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.338321",
+      "modified": "2025-06-09 14:13:29.338341"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 291,
     "fields": {
-      "id": "291",
-      "created": "2025-06-09 14:13:29.340498",
-      "modified": "2025-06-09 14:13:29.340517",
-      "logo": "",
-      "safa_id": "NTRBW",
       "name": "SAFA CAPE DISTRICT LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "NTRBW",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.340498",
+      "modified": "2025-06-09 14:13:29.340517"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 292,
     "fields": {
-      "id": "292",
-      "created": "2025-06-09 14:13:29.343015",
-      "modified": "2025-06-09 14:13:29.343041",
-      "logo": "",
-      "safa_id": "523DQ",
       "name": "SAFA CAPE TOWN TYGERBERG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "523DQ",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.343015",
+      "modified": "2025-06-09 14:13:29.343041"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 293,
     "fields": {
-      "id": "293",
-      "created": "2025-06-09 14:13:29.345788",
-      "modified": "2025-06-09 14:13:29.345815",
-      "logo": "",
-      "safa_id": "OMCT2",
       "name": "SAFA CROSSROADS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "OMCT2",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.345788",
+      "modified": "2025-06-09 14:13:29.345815"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 294,
     "fields": {
-      "id": "294",
-      "created": "2025-06-09 14:13:29.348095",
-      "modified": "2025-06-09 14:13:29.348117",
-      "logo": "",
-      "safa_id": "F45QX",
       "name": "SAFA DELFT LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "F45QX",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.348095",
+      "modified": "2025-06-09 14:13:29.348117"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 295,
     "fields": {
-      "id": "295",
-      "created": "2025-06-09 14:13:29.350398",
-      "modified": "2025-06-09 14:13:29.350420",
-      "logo": "",
-      "safa_id": "6EOZC",
       "name": "SAFA DUNOON LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "6EOZC",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.350398",
+      "modified": "2025-06-09 14:13:29.350420"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 296,
     "fields": {
-      "id": "296",
-      "created": "2025-06-09 14:13:29.352629",
-      "modified": "2025-06-09 14:13:29.352667",
-      "logo": "",
-      "safa_id": "12IOR",
       "name": "SAFA GOODHOPE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "12IOR",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.352629",
+      "modified": "2025-06-09 14:13:29.352667"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 297,
     "fields": {
-      "id": "297",
-      "created": "2025-06-09 14:13:29.354853",
-      "modified": "2025-06-09 14:13:29.354873",
-      "logo": "",
-      "safa_id": "CLBRH",
       "name": "SAFA GUGULETHU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "CLBRH",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.354853",
+      "modified": "2025-06-09 14:13:29.354873"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 298,
     "fields": {
-      "id": "298",
-      "created": "2025-06-09 14:13:29.357017",
-      "modified": "2025-06-09 14:13:29.357037",
-      "logo": "",
-      "safa_id": "DSRJW",
       "name": "SAFA HELDERBERG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "DSRJW",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.357017",
+      "modified": "2025-06-09 14:13:29.357037"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 299,
     "fields": {
-      "id": "299",
-      "created": "2025-06-09 14:13:29.359279",
-      "modified": "2025-06-09 14:13:29.359298",
-      "logo": "",
-      "safa_id": "UILR9",
       "name": "SAFA KHAYELITSHA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "UILR9",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.359279",
+      "modified": "2025-06-09 14:13:29.359298"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 300,
     "fields": {
-      "id": "300",
-      "created": "2025-06-09 14:13:29.361429",
-      "modified": "2025-06-09 14:13:29.361449",
-      "logo": "",
-      "safa_id": "E2LSP",
       "name": "SAFA LANGA NDABENI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "E2LSP",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.361429",
+      "modified": "2025-06-09 14:13:29.361449"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 301,
     "fields": {
-      "id": "301",
-      "created": "2025-06-09 14:13:29.363544",
-      "modified": "2025-06-09 14:13:29.363563",
-      "logo": "",
-      "safa_id": "590O5",
       "name": "SAFA LINGELETHU LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "590O5",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.363544",
+      "modified": "2025-06-09 14:13:29.363563"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 302,
     "fields": {
-      "id": "302",
-      "created": "2025-06-09 14:13:29.365875",
-      "modified": "2025-06-09 14:13:29.365894",
-      "logo": "",
-      "safa_id": "ABANQ",
       "name": "SAFA MAKHAZA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "ABANQ",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.365875",
+      "modified": "2025-06-09 14:13:29.365894"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 303,
     "fields": {
-      "id": "303",
-      "created": "2025-06-09 14:13:29.368015",
-      "modified": "2025-06-09 14:13:29.368035",
-      "logo": "",
-      "safa_id": "IISCW",
       "name": "SAFA MANDALAY LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "IISCW",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.368015",
+      "modified": "2025-06-09 14:13:29.368035"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 304,
     "fields": {
-      "id": "304",
-      "created": "2025-06-09 14:13:29.370179",
-      "modified": "2025-06-09 14:13:29.370198",
-      "logo": "",
-      "safa_id": "L3GW6",
       "name": "SAFA MANDELA PARK LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "L3GW6",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.370179",
+      "modified": "2025-06-09 14:13:29.370198"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 305,
     "fields": {
-      "id": "305",
-      "created": "2025-06-09 14:13:29.372271",
-      "modified": "2025-06-09 14:13:29.372290",
-      "logo": "",
-      "safa_id": "EGLYE",
       "name": "SAFA MANENBERG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "EGLYE",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.372271",
+      "modified": "2025-06-09 14:13:29.372290"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 306,
     "fields": {
-      "id": "306",
-      "created": "2025-06-09 14:13:29.374360",
-      "modified": "2025-06-09 14:13:29.374379",
-      "logo": "",
-      "safa_id": "HOMCY",
       "name": "SAFA METROPOLITAN LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "HOMCY",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.374360",
+      "modified": "2025-06-09 14:13:29.374379"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 307,
     "fields": {
-      "id": "307",
-      "created": "2025-06-09 14:13:29.376556",
-      "modified": "2025-06-09 14:13:29.376575",
-      "logo": "",
-      "safa_id": "4RVBK",
       "name": "SAFA MFULENI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "4RVBK",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.376556",
+      "modified": "2025-06-09 14:13:29.376575"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 308,
     "fields": {
-      "id": "308",
-      "created": "2025-06-09 14:13:29.378694",
-      "modified": "2025-06-09 14:13:29.378713",
-      "logo": "",
-      "safa_id": "KS6JZ",
       "name": "SAFA MITCHELLS PLAIN LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "KS6JZ",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.378694",
+      "modified": "2025-06-09 14:13:29.378713"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 309,
     "fields": {
-      "id": "309",
-      "created": "2025-06-09 14:13:29.380786",
-      "modified": "2025-06-09 14:13:29.380805",
-      "logo": "",
-      "safa_id": "ZIZHX",
       "name": "SAFA NEW CROSSROADS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "ZIZHX",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.380786",
+      "modified": "2025-06-09 14:13:29.380805"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 310,
     "fields": {
-      "id": "310",
-      "created": "2025-06-09 14:13:29.382874",
-      "modified": "2025-06-09 14:13:29.382893",
-      "logo": "",
-      "safa_id": "BVD1E",
       "name": "SAFA NORTHERN SUBURBS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "BVD1E",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.382874",
+      "modified": "2025-06-09 14:13:29.382893"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 311,
     "fields": {
-      "id": "311",
-      "created": "2025-06-09 14:13:29.385290",
-      "modified": "2025-06-09 14:13:29.385314",
-      "logo": "",
-      "safa_id": "PSU6G",
       "name": "SAFA NYANGA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "PSU6G",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.385290",
+      "modified": "2025-06-09 14:13:29.385314"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 312,
     "fields": {
-      "id": "312",
-      "created": "2025-06-09 14:13:29.387511",
-      "modified": "2025-06-09 14:13:29.387530",
-      "logo": "",
-      "safa_id": "APM8A",
       "name": "SAFA OOSTENBERG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "APM8A",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.387511",
+      "modified": "2025-06-09 14:13:29.387530"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 313,
     "fields": {
-      "id": "313",
-      "created": "2025-06-09 14:13:29.389626",
-      "modified": "2025-06-09 14:13:29.389645",
-      "logo": "",
-      "safa_id": "4BM7J",
       "name": "SAFA PHILLIPI LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "4BM7J",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.389626",
+      "modified": "2025-06-09 14:13:29.389645"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 314,
     "fields": {
-      "id": "314",
-      "created": "2025-06-09 14:13:29.391743",
-      "modified": "2025-06-09 14:13:29.391762",
-      "logo": "",
-      "safa_id": "DVZ51",
       "name": "SAFA RYGATE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "DVZ51",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.391743",
+      "modified": "2025-06-09 14:13:29.391762"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 315,
     "fields": {
-      "id": "315",
-      "created": "2025-06-09 14:13:29.393936",
-      "modified": "2025-06-09 14:13:29.393955",
-      "logo": "",
-      "safa_id": "7ZPYL",
       "name": "SAFA SOUTH PENINSULA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "7ZPYL",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.393936",
+      "modified": "2025-06-09 14:13:29.393955"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 316,
     "fields": {
-      "id": "316",
-      "created": "2025-06-09 14:13:29.396067",
-      "modified": "2025-06-09 14:13:29.396086",
-      "logo": "",
-      "safa_id": "5SOLF",
       "name": "SAFA SIMUNYE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "5SOLF",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.396067",
+      "modified": "2025-06-09 14:13:29.396086"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 317,
     "fields": {
-      "id": "317",
-      "created": "2025-06-09 14:13:29.398158",
-      "modified": "2025-06-09 14:13:29.398177",
-      "logo": "",
-      "safa_id": "ACB4C",
       "name": "SAFA TWO OCEANS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "47"
+      "logo": "",
+      "safa_id": "ACB4C",
+      "region": 47,
+      "association": 4,
+      "created": "2025-06-09 14:13:29.398158",
+      "modified": "2025-06-09 14:13:29.398177"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 318,
     "fields": {
-      "id": "318",
-      "created": "2025-06-09 14:16:36.589679",
-      "modified": "2025-06-09 14:16:36.589746",
-      "logo": "",
-      "safa_id": "X58R6",
       "name": "SAFA BREEDE VALLEY LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "48"
+      "logo": "",
+      "safa_id": "X58R6",
+      "region": 48,
+      "association": 4,
+      "created": "2025-06-09 14:16:36.589679",
+      "modified": "2025-06-09 14:16:36.589746"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 319,
     "fields": {
-      "id": "319",
-      "created": "2025-06-09 14:16:36.596249",
-      "modified": "2025-06-09 14:16:36.596303",
-      "logo": "",
-      "safa_id": "647EG",
       "name": "SAFA DRAKENSTEIN LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "48"
+      "logo": "",
+      "safa_id": "647EG",
+      "region": 48,
+      "association": 4,
+      "created": "2025-06-09 14:16:36.596249",
+      "modified": "2025-06-09 14:16:36.596303"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 320,
     "fields": {
-      "id": "320",
-      "created": "2025-06-09 14:16:36.601767",
-      "modified": "2025-06-09 14:16:36.601817",
-      "logo": "",
-      "safa_id": "2L9N3",
       "name": "SAFA LANGEBERG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "48"
+      "logo": "",
+      "safa_id": "2L9N3",
+      "region": 48,
+      "association": 4,
+      "created": "2025-06-09 14:16:36.601767",
+      "modified": "2025-06-09 14:16:36.601817"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 321,
     "fields": {
-      "id": "321",
-      "created": "2025-06-09 14:16:36.606368",
-      "modified": "2025-06-09 14:16:36.606411",
-      "logo": "",
-      "safa_id": "DRUOW",
       "name": "SAFA STELLENBOSCH LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "48"
+      "logo": "",
+      "safa_id": "DRUOW",
+      "region": 48,
+      "association": 4,
+      "created": "2025-06-09 14:16:36.606368",
+      "modified": "2025-06-09 14:16:36.606411"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 322,
     "fields": {
-      "id": "322",
-      "created": "2025-06-09 14:16:36.611160",
-      "modified": "2025-06-09 14:16:36.611201",
-      "logo": "",
-      "safa_id": "BT9YX",
       "name": "SAFA WITZENBERG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "48"
+      "logo": "",
+      "safa_id": "BT9YX",
+      "region": 48,
+      "association": 4,
+      "created": "2025-06-09 14:16:36.611160",
+      "modified": "2025-06-09 14:16:36.611201"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 323,
     "fields": {
-      "id": "323",
-      "created": "2025-06-09 14:18:28.528258",
-      "modified": "2025-06-09 14:18:28.528318",
-      "logo": "",
-      "safa_id": "PED7X",
       "name": "SAFA BEAUFORT WEST LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "49"
+      "logo": "",
+      "safa_id": "PED7X",
+      "region": 49,
+      "association": 4,
+      "created": "2025-06-09 14:18:28.528258",
+      "modified": "2025-06-09 14:18:28.528318"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 324,
     "fields": {
-      "id": "324",
-      "created": "2025-06-09 14:18:28.533348",
-      "modified": "2025-06-09 14:18:28.533391",
-      "logo": "",
-      "safa_id": "OAKE2",
       "name": "SAFA LAINGSBURG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "49"
+      "logo": "",
+      "safa_id": "OAKE2",
+      "region": 49,
+      "association": 4,
+      "created": "2025-06-09 14:18:28.533348",
+      "modified": "2025-06-09 14:18:28.533391"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 325,
     "fields": {
-      "id": "325",
-      "created": "2025-06-09 14:18:28.537596",
-      "modified": "2025-06-09 14:18:28.537636",
-      "logo": "",
-      "safa_id": "QC9WC",
       "name": "SAFA PRINCE ALBERT LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "49"
+      "logo": "",
+      "safa_id": "QC9WC",
+      "region": 49,
+      "association": 4,
+      "created": "2025-06-09 14:18:28.537596",
+      "modified": "2025-06-09 14:18:28.537636"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 326,
     "fields": {
-      "id": "326",
-      "created": "2025-06-09 14:19:45.996299",
-      "modified": "2025-06-09 14:19:45.996359",
-      "logo": "",
-      "safa_id": "IEYER",
       "name": "SAFA HESSEQUA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "50"
+      "logo": "",
+      "safa_id": "IEYER",
+      "region": 50,
+      "association": 4,
+      "created": "2025-06-09 14:19:45.996299",
+      "modified": "2025-06-09 14:19:45.996359"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 327,
     "fields": {
-      "id": "327",
-      "created": "2025-06-09 14:19:46.001454",
-      "modified": "2025-06-09 14:19:46.001497",
-      "logo": "",
-      "safa_id": "P1FY3",
       "name": "SAFA GEORGE LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "50"
+      "logo": "",
+      "safa_id": "P1FY3",
+      "region": 50,
+      "association": 4,
+      "created": "2025-06-09 14:19:46.001454",
+      "modified": "2025-06-09 14:19:46.001497"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 328,
     "fields": {
-      "id": "328",
-      "created": "2025-06-09 14:19:46.006033",
-      "modified": "2025-06-09 14:19:46.006093",
-      "logo": "",
-      "safa_id": "EE3DL",
       "name": "SAFA KANNALAND LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "50"
+      "logo": "",
+      "safa_id": "EE3DL",
+      "region": 50,
+      "association": 4,
+      "created": "2025-06-09 14:19:46.006033",
+      "modified": "2025-06-09 14:19:46.006093"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 329,
     "fields": {
-      "id": "329",
-      "created": "2025-06-09 14:19:46.011067",
-      "modified": "2025-06-09 14:19:46.011116",
-      "logo": "",
-      "safa_id": "F8NGO",
       "name": "SAFA KNYSNA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "50"
+      "logo": "",
+      "safa_id": "F8NGO",
+      "region": 50,
+      "association": 4,
+      "created": "2025-06-09 14:19:46.011067",
+      "modified": "2025-06-09 14:19:46.011116"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 330,
     "fields": {
-      "id": "330",
-      "created": "2025-06-09 14:19:46.015571",
-      "modified": "2025-06-09 14:19:46.015613",
-      "logo": "",
-      "safa_id": "SF4XR",
       "name": "SAFA MOSSEL BAY LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "50"
+      "logo": "",
+      "safa_id": "SF4XR",
+      "region": 50,
+      "association": 4,
+      "created": "2025-06-09 14:19:46.015571",
+      "modified": "2025-06-09 14:19:46.015613"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 331,
     "fields": {
-      "id": "331",
-      "created": "2025-06-09 14:19:46.019686",
-      "modified": "2025-06-09 14:19:46.019725",
-      "logo": "",
-      "safa_id": "NHKQC",
       "name": "SAFA OUDTSHOORN LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "50"
+      "logo": "",
+      "safa_id": "NHKQC",
+      "region": 50,
+      "association": 4,
+      "created": "2025-06-09 14:19:46.019686",
+      "modified": "2025-06-09 14:19:46.019725"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 332,
     "fields": {
-      "id": "332",
-      "created": "2025-06-09 14:19:46.023799",
-      "modified": "2025-06-09 14:19:46.023836",
-      "logo": "",
-      "safa_id": "0PDAB",
       "name": "SAFA PLETTENBERG BAY LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "50"
+      "logo": "",
+      "safa_id": "0PDAB",
+      "region": 50,
+      "association": 4,
+      "created": "2025-06-09 14:19:46.023799",
+      "modified": "2025-06-09 14:19:46.023836"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 333,
     "fields": {
-      "id": "333",
-      "created": "2025-06-09 14:20:35.496885",
-      "modified": "2025-06-09 14:20:35.496920",
-      "logo": "",
-      "safa_id": "LXJRD",
       "name": "SAFA CAPE ALGULHAS LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "51"
+      "logo": "",
+      "safa_id": "LXJRD",
+      "region": 51,
+      "association": 4,
+      "created": "2025-06-09 14:20:35.496885",
+      "modified": "2025-06-09 14:20:35.496920"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 334,
     "fields": {
-      "id": "334",
-      "created": "2025-06-09 14:20:35.499819",
-      "modified": "2025-06-09 14:20:35.499844",
-      "logo": "",
-      "safa_id": "55S3D",
       "name": "SAFA GAANSBAY LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "51"
+      "logo": "",
+      "safa_id": "55S3D",
+      "region": 51,
+      "association": 4,
+      "created": "2025-06-09 14:20:35.499819",
+      "modified": "2025-06-09 14:20:35.499844"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 335,
     "fields": {
-      "id": "335",
-      "created": "2025-06-09 14:20:35.502184",
-      "modified": "2025-06-09 14:20:35.502205",
-      "logo": "",
-      "safa_id": "JQAVN",
       "name": "SAFA SWELLENDAM LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "51"
+      "logo": "",
+      "safa_id": "JQAVN",
+      "region": 51,
+      "association": 4,
+      "created": "2025-06-09 14:20:35.502184",
+      "modified": "2025-06-09 14:20:35.502205"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 336,
     "fields": {
-      "id": "336",
-      "created": "2025-06-09 14:20:35.504323",
-      "modified": "2025-06-09 14:20:35.504343",
-      "logo": "",
-      "safa_id": "16AY9",
       "name": "SAFA THREEWATERSKLOOF LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "51"
+      "logo": "",
+      "safa_id": "16AY9",
+      "region": 51,
+      "association": 4,
+      "created": "2025-06-09 14:20:35.504323",
+      "modified": "2025-06-09 14:20:35.504343"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 337,
     "fields": {
-      "id": "337",
-      "created": "2025-06-09 14:21:46.637292",
-      "modified": "2025-06-09 14:21:46.637354",
-      "logo": "",
-      "safa_id": "JZM2S",
       "name": "SAFA BERGRIVIER LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "52"
+      "logo": "",
+      "safa_id": "JZM2S",
+      "region": 52,
+      "association": 4,
+      "created": "2025-06-09 14:21:46.637292",
+      "modified": "2025-06-09 14:21:46.637354"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 338,
     "fields": {
-      "id": "338",
-      "created": "2025-06-09 14:21:46.642210",
-      "modified": "2025-06-09 14:21:46.642250",
-      "logo": "",
-      "safa_id": "792MY",
       "name": "SAFA CEDERBERG LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "52"
+      "logo": "",
+      "safa_id": "792MY",
+      "region": 52,
+      "association": 4,
+      "created": "2025-06-09 14:21:46.642210",
+      "modified": "2025-06-09 14:21:46.642250"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 339,
     "fields": {
-      "id": "339",
-      "created": "2025-06-09 14:21:46.647039",
-      "modified": "2025-06-09 14:21:46.647083",
-      "logo": "",
-      "safa_id": "6KHTX",
       "name": "SAFA MATZIKAMA LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "52"
+      "logo": "",
+      "safa_id": "6KHTX",
+      "region": 52,
+      "association": 4,
+      "created": "2025-06-09 14:21:46.647039",
+      "modified": "2025-06-09 14:21:46.647083"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 340,
     "fields": {
-      "id": "340",
-      "created": "2025-06-09 14:21:46.651627",
-      "modified": "2025-06-09 14:21:46.651687",
+      "name": "SAFA SALDANHA LFA",
+      "acronym": "SALDAN",
+      "website": "",
+      "headquarters": "SALDANHA",
+      "description": "",
       "logo": "",
       "safa_id": "JGQ1M",
-      "name": "SAFA SALDANHA LFA",
-      "acronym": "",
-      "website": "",
-      "headquarters": "",
-      "description": "",
-      "association_id": "4",
-      "region_id": "52"
+      "region": 52,
+      "association": 4,
+      "created": "2025-06-09 14:21:46.651627",
+      "modified": "2025-06-17 17:48:57.508326"
     }
   },
   {
     "model": "geography.localfootballassociation",
     "pk": 341,
     "fields": {
-      "id": "341",
-      "created": "2025-06-09 14:21:46.655973",
-      "modified": "2025-06-09 14:21:46.656009",
-      "logo": "",
-      "safa_id": "X459O",
       "name": "SAFA SWARTLAND LFA",
       "acronym": "",
       "website": "",
       "headquarters": "",
       "description": "",
-      "association_id": "4",
-      "region_id": "52"
+      "logo": "",
+      "safa_id": "X459O",
+      "region": 52,
+      "association": 4,
+      "created": "2025-06-09 14:21:46.655973",
+      "modified": "2025-06-09 14:21:46.656009"
     }
   }
 ]

--- a/scripts/load_lfa_data.py
+++ b/scripts/load_lfa_data.py
@@ -1,0 +1,66 @@
+import json
+import os
+
+def migrate_lfa_data():
+    """
+    Reads LFA data from a backup file, transforms it into the Django fixture format,
+    and writes it to the official fixture file.
+    """
+    # Define file paths
+    # Assuming the script is run from the root of the repository
+    backup_file_path = 'databackup29072025/geography_localfootballassociation.json'
+    fixture_file_path = 'geography/fixtures/geography_localfootballassociation.json'
+
+    # Read the backup data
+    try:
+        with open(backup_file_path, 'r') as f:
+            backup_data = json.load(f)
+    except FileNotFoundError:
+        print(f"Error: Backup file not found at {backup_file_path}")
+        return
+    except json.JSONDecodeError:
+        print(f"Error: Could not decode JSON from {backup_file_path}")
+        return
+
+    new_fixture_data = []
+    for record in backup_data:
+        # The pk for the fixture entry
+        pk = record.get('id')
+        if pk is None:
+            continue  # Skip records without an ID
+
+        # Create the fields dictionary for the fixture
+        fields = {
+            "name": record.get("name"),
+            "acronym": record.get("acronym", ""),
+            "website": record.get("website", ""),
+            "headquarters": record.get("headquarters", ""),
+            "description": record.get("description", ""),
+            "logo": record.get("logo", ""),
+            "safa_id": record.get("safa_id"),
+            "region": record.get("region_id"),
+            "association": record.get("association_id"),
+            "created": record.get("created"),
+            "modified": record.get("modified"),
+        }
+
+        # Create the full fixture entry
+        fixture_entry = {
+            "model": "geography.localfootballassociation",
+            "pk": pk,
+            "fields": fields
+        }
+        new_fixture_data.append(fixture_entry)
+
+    # Write the new fixture data to the file
+    try:
+        # Ensure the directory exists
+        os.makedirs(os.path.dirname(fixture_file_path), exist_ok=True)
+        with open(fixture_file_path, 'w') as f:
+            json.dump(new_fixture_data, f, indent=2)
+        print(f"Successfully migrated data to {fixture_file_path}")
+    except IOError as e:
+        print(f"Error writing to fixture file {fixture_file_path}: {e}")
+
+if __name__ == "__main__":
+    migrate_lfa_data()


### PR DESCRIPTION
This commit introduces several changes:

- Displays the `safa_id` for `Region` and `Province` models in the Django admin interface.
- Adds a new script `scripts/load_lfa_data.py` to migrate Local Football Association (LFA) data from a backup file to a fixture file.
- Updates the `geography/fixtures/geography_localfootballassociation.json` fixture with the data from the backup, ensuring correct formatting and foreign key references.