### PR TITLE
feat: Implement National Admin registration and dashboard

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -17,12 +17,43 @@ class NationalAdminRegistrationForm(forms.ModelForm):
     password = forms.CharField(widget=forms.PasswordInput)
     password2 = forms.CharField(label='Confirm password', widget=forms.PasswordInput)
 
+    organization_type = forms.ModelChoiceField(
+        queryset=OrganizationType.objects.all(),
+        required=True,
+        label="Administrator Type",
+        help_text="Select the type of organization you will be administering."
+    )
+    position = forms.ModelChoiceField(
+        queryset=Position.objects.all(),
+        required=True,
+        label="Position",
+        help_text="Select your position within the organization."
+    )
+    province = forms.ModelChoiceField(
+        queryset=Province.objects.all(),
+        required=False,
+    )
+    region = forms.ModelChoiceField(
+        queryset=Region.objects.all(),
+        required=False,
+    )
+    local_federation = forms.ModelChoiceField(
+        queryset=LocalFootballAssociation.objects.all(),
+        required=False,
+        label="Local Football Association"
+    )
+    club = forms.ModelChoiceField(
+        queryset=Club.objects.all(),
+        required=False,
+    )
+
     class Meta:
         model = CustomUser
         fields = [
             'first_name', 'last_name', 'email', 'id_number', 'passport_number',
             'date_of_birth', 'gender', 'profile_picture', 'id_document',
-            'popi_act_consent'
+            'popi_act_consent', 'organization_type', 'position', 'province',
+            'region', 'local_federation', 'club'
         ]
 
     def clean_password2(self):

--- a/accounts/templates/accounts/member_approvals_list.html
+++ b/accounts/templates/accounts/member_approvals_list.html
@@ -19,24 +19,56 @@
                     <thead class="table-light">
                         <tr>
                             <th>Name</th>
-                            <th>SAFA ID</th>
-                            <th>ID Number</th>
-                            <th>Club</th>
+                            <th>Email</th>
+                            <th>Role</th>
+                            <th>Organization</th>
                             <th>Registration Date</th>
                             <th class="text-center">Actions</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for member in pending_members %}
+                        {% for member in members_to_approve %}
                         <tr id="member-row-{{ member.id }}">
                             <td>{{ member.get_full_name }}</td>
-                            <td>{{ member.safa_id|default:"N/A" }}</td>
-                            <td>{{ member.id_number|default:"N/A" }}</td>
-                            <td>{{ member.club.name|default:"N/A" }}</td>
-                            <td>{{ member.date_joined|date:"Y-m-d" }}</td>
+                            <td>{{ member.email|default:"N/A" }}</td>
+                            <td>{{ member.role|default:"N/A" }}</td>
+                            <td>{{ member.current_club.name|default:"N/A" }}</td>
+                            <td>{{ member.created|date:"Y-m-d" }}</td>
                             <td class="text-center">
-                                <button class="btn btn-success btn-sm approve-btn" data-member-id="{{ member.id }}">Approve</button>
-                                <a href="{% url 'accounts:reject_member' member.id %}" class="btn btn-danger btn-sm">Reject</a>
+                                <form action="{% url 'accounts:member_approvals_list' %}" method="post" class="d-inline">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="member_id" value="{{ member.id }}">
+                                    <button type="submit" name="approve" class="btn btn-success btn-sm">Approve</button>
+                                </form>
+                                <button type="button" class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#rejectModal-{{ member.id }}">
+                                    Reject
+                                </button>
+
+                                <!-- Reject Modal -->
+                                <div class="modal fade" id="rejectModal-{{ member.id }}" tabindex="-1" aria-labelledby="rejectModalLabel-{{ member.id }}" aria-hidden="true">
+                                  <div class="modal-dialog">
+                                    <div class="modal-content">
+                                      <form action="{% url 'accounts:member_approvals_list' %}" method="post">
+                                          {% csrf_token %}
+                                          <input type="hidden" name="member_id" value="{{ member.id }}">
+                                          <div class="modal-header">
+                                            <h5 class="modal-title" id="rejectModalLabel-{{ member.id }}">Reject Member: {{ member.get_full_name }}</h5>
+                                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                          </div>
+                                          <div class="modal-body">
+                                            <div class="mb-3">
+                                                <label for="rejection_reason-{{ member.id }}" class="form-label">Reason for Rejection</label>
+                                                <textarea class="form-control" id="rejection_reason-{{ member.id }}" name="rejection_reason" rows="3" required></textarea>
+                                            </div>
+                                          </div>
+                                          <div class="modal-footer">
+                                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                            <button type="submit" name="reject" class="btn btn-danger">Confirm Rejection</button>
+                                          </div>
+                                      </form>
+                                    </div>
+                                  </div>
+                                </div>
                             </td>
                         </tr>
                         {% empty %}
@@ -50,33 +82,4 @@
         </div>
     </div>
 </div>
-
-{% block extra_js %}
-<script>
-document.querySelectorAll('.approve-btn').forEach(button => {
-    button.addEventListener('click', function() {
-        const memberId = this.dataset.memberId;
-        const row = document.getElementById(`member-row-${memberId}`);
-
-        fetch("{% url 'accounts:quick_approve_member' %}", {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-                'X-CSRFToken': '{{ csrf_token }}'
-            },
-            body: `member_id=${memberId}`
-        })
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                row.style.display = 'none';
-                // You can also add a success message here
-            } else {
-                alert('Error approving member: ' + data.error);
-            }
-        });
-    });
-});
-</script>
-{% endblock %}
 {% endblock %}

--- a/accounts/templates/accounts/national_admin_dashboard.html
+++ b/accounts/templates/accounts/national_admin_dashboard.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}National Admin Dashboard{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2 class="mb-4">National Administrator Dashboard</h2>
+
+    {% if messages %}
+        {% for message in messages %}
+            <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endfor %}
+    {% endif %}
+
+    {% for org_type, org_list, org_name_plural in org_data %}
+    <div class="card shadow-sm mb-4">
+        <div class="card-header">
+            <h4 class="mb-0">{{ org_name_plural }}</h4>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-hover">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Name</th>
+                            <th class="text-center">Current Status</th>
+                            <th class="text-center">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for org in org_list %}
+                        <tr>
+                            <td>{{ org.name }}</td>
+                            <td class="text-center">
+                                <span class="badge
+                                    {% if org.status == 'ACTIVE' %}bg-success
+                                    {% elif org.status == 'INACTIVE' %}bg-secondary
+                                    {% elif org.status == 'SUSPENDED' %}bg-warning
+                                    {% else %}bg-danger
+                                    {% endif %}">
+                                    {{ org.get_status_display }}
+                                </span>
+                            </td>
+                            <td class="text-center">
+                                <form action="{% url 'accounts:update_organization_status' %}" method="post" class="d-inline">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="org_type" value="{{ org_type }}">
+                                    <input type="hidden" name="org_id" value="{{ org.id }}">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+                                            Change Status
+                                        </button>
+                                        <ul class="dropdown-menu">
+                                            {% for status_key, status_value in ClubStatus.choices %}
+                                            <li>
+                                                <button class="dropdown-item" type="submit" name="new_status" value="{{ status_key }}">
+                                                    Set as {{ status_value }}
+                                                </button>
+                                            </li>
+                                            {% endfor %}
+                                        </ul>
+                                    </div>
+                                </form>
+                            </td>
+                        </tr>
+                        {% empty %}
+                        <tr>
+                            <td colspan="3" class="text-center text-muted">No {{ org_name_plural }} found.</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -53,4 +53,8 @@ urlpatterns = [
     path('registration-portal/', views.registration_portal, name='registration_portal'),
     path('update-profile-photo/', views.update_profile_photo, name='update_profile_photo'),
     path('senior-membership-dashboard/', views.senior_membership_dashboard, name='senior_membership_dashboard'),
+
+    # National Admin Dashboard
+    path('national-admin-dashboard/', views.national_admin_dashboard, name='national_admin_dashboard'),
+    path('update-organization-status/', views.update_organization_status, name='update_organization_status'),
 ]

--- a/geography/models.py
+++ b/geography/models.py
@@ -278,6 +278,12 @@ class Province(TimeStampedModel, ModelWithLogo):
         help_text=_('The national federation this province belongs to')
     )
     description = models.TextField(_('Description'), blank=True)
+    status = models.CharField(
+        _('Status'),
+        max_length=20,
+        choices=ClubStatus.choices,
+        default=ClubStatus.INACTIVE
+    )
     # Add safa_id field manually without mixin to avoid conflicts
     safa_id = models.CharField(
         _("SAFA ID"),
@@ -304,6 +310,12 @@ class Region(TimeStampedModel, ModelWithLogo, SAFAIdentifiableMixin):
         on_delete=models.CASCADE
     )
     description = models.TextField(_('Description'), blank=True)
+    status = models.CharField(
+        _('Status'),
+        max_length=20,
+        choices=ClubStatus.choices,
+        default=ClubStatus.INACTIVE
+    )
     
     class Meta:
         verbose_name = _('Region')
@@ -324,6 +336,12 @@ class Association(TimeStampedModel, ModelWithLogo, SAFAIdentifiableMixin):
     website = models.URLField(_('Website'), max_length=200, blank=True)
     headquarters = models.CharField(_('Headquarters'), max_length=100, blank=True)
     description = models.TextField(_('Description'), blank=True)
+    status = models.CharField(
+        _('Status'),
+        max_length=20,
+        choices=ClubStatus.choices,
+        default=ClubStatus.INACTIVE
+    )
     
     class Meta:
         verbose_name = _('Association')
@@ -352,6 +370,12 @@ class LocalFootballAssociation(TimeStampedModel, ModelWithLogo, SAFAIdentifiable
     website = models.URLField(_('Website'), max_length=200, blank=True)
     headquarters = models.CharField(_('Headquarters'), max_length=100, blank=True)
     description = models.TextField(_('Description'), blank=True)
+    status = models.CharField(
+        _('Status'),
+        max_length=20,
+        choices=ClubStatus.choices,
+        default=ClubStatus.INACTIVE
+    )
     
     class Meta:
         verbose_name = _('Local Football Association')


### PR DESCRIPTION
This commit introduces a complete overhaul of the administrator registration and management system.

Key features and changes:
- Refactored the administrator registration form and view to support all administrator types (National, Province, Region, LFA, Club).
- The new registration process now correctly creates a `CustomUser`, a `Member` profile, and a `UserRole`, associating the administrator with the correct organizational unit and setting their status to 'Pending Approval'.
- Implemented an approval workflow where a National Administrator or superuser can approve or reject pending members.
- Upon approval, an invoice is automatically generated for the member's registration fee based on the defined fee structure.
- Developed a new dashboard for the National Administrator, providing a centralized place to manage all organizations in the hierarchy.
- Added a 'status' field to Province, Region, LFA, and Association models, allowing the National Admin to activate or deactivate them from the new dashboard.
- Ensured the new views are protected with the appropriate role-based permissions.