### PR TITLE
feat: Implement National Admin registration and dashboard

### DIFF
--- a/geography/models.py
+++ b/geography/models.py
@@ -73,6 +73,12 @@ CONTINENT = (
     ('SA', _('South America')),
 )
 
+class ClubStatus(models.TextChoices):
+    ACTIVE = 'ACTIVE', _('Active')
+    INACTIVE = 'INACTIVE', _('Inactive')
+    SUSPENDED = 'SUSPENDED', _('Suspended')
+    DISSOLVED = 'DISSOLVED', _('Dissolved')
+
 # ===== BASE MODELS =====
 
 
@@ -266,12 +272,6 @@ class NationalFederation(TimeStampedModel, ModelWithLogo, SAFAIdentifiableMixin)
     
     def __str__(self):
         return f"{self.name} ({self.country.name})"
-
-class ClubStatus(models.TextChoices):
-    ACTIVE = 'ACTIVE', _('Active')
-    INACTIVE = 'INACTIVE', _('Inactive')
-    SUSPENDED = 'SUSPENDED', _('Suspended')
-    DISSOLVED = 'DISSOLVED', _('Dissolved')
 
 class Province(TimeStampedModel, ModelWithLogo):
     """Represents a province/state within a national federation (e.g., Western Cape)"""


### PR DESCRIPTION
This commit introduces a complete overhaul of the administrator registration and management system.

Key features and changes:
- Refactored the administrator registration form and view to support all administrator types (National, Province, Region, LFA, Club).
- The new registration process now correctly creates a `CustomUser`, a `Member` profile, and a `UserRole`, associating the administrator with the correct organizational unit and setting their status to 'Pending Approval'.
- Implemented an approval workflow where a National Administrator or superuser can approve or reject pending members.
- Upon approval, an invoice is automatically generated for the member's registration fee based on the defined fee structure.
- Developed a new dashboard for the National Administrator, providing a centralized place to manage all organizations in the hierarchy.
- Added a 'status' field to Province, Region, LFA, and Association models, allowing the National Admin to activate or deactivate them from the new dashboard.
- Ensured the new views are protected with the appropriate role-based permissions.

Fixes NameError for ClubStatus by reordering class definition in geography/models.py.