### PR TITLE
Simplify Club location selection in the admin panel.

### DIFF
--- a/geography/admin.py
+++ b/geography/admin.py
@@ -178,13 +178,20 @@ class ClubAdmin(ModelWithLogoAdmin):
         'name', 'localfootballassociation', 'region', 'province', 'status', 'safa_id', 'display_logo'
     ]
     list_filter = [
-        'localfootballassociation', 'region', 'province', 'status'
+        'localfootballassociation', 'status'
     ]
     search_fields = [
         'name', 'localfootballassociation__name', 'region__name', 'province__name', 'safa_id'
     ]
+    readonly_fields = ('province', 'region')
     list_editable = []
     inlines = [PlayerInline, OfficialInline]
+
+    def save_model(self, request, obj, form, change):
+        if obj.localfootballassociation:
+            obj.region = obj.localfootballassociation.region
+            obj.province = obj.localfootballassociation.region.province
+        super().save_model(request, obj, form, change)
     
     
 # Register models


### PR DESCRIPTION
This change simplifies the process of selecting the province and region when creating or editing a Club in the Django admin.

- The `province` and `region` fields in the `ClubAdmin` are now read-only, as their values are derived from the selected `LocalFootballAssociation`.
- The `save_model` method in `ClubAdmin` is overridden to automatically populate the `province` and `region` based on the selected `LocalFootballAssociation` when the club is saved.

This eliminates the need for the user to manually select the province and region, reducing the chance of errors and improving the user experience.