### PR TITLE
fix: Add links to administrator registration and dashboard

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -641,6 +641,11 @@
                                     <i class="fas fa-cogs me-1"></i>Administration
                                 </a>
                                 <ul class="dropdown-menu">
+                                    {% if user.role == 'ADMIN_NATIONAL' %}
+                                    <li><a class="dropdown-item" href="{% url 'accounts:national_admin_dashboard' %}">
+                                        <i class="fas fa-shield-alt me-2"></i>National Dashboard
+                                    </a></li>
+                                    {% endif %}
                                     <li><a class="dropdown-item" href="{% url 'accounts:member_approvals_list' %}">
                                         <i class="fas fa-user-check me-2"></i>Member Approvals
                                     </a></li>
@@ -683,6 +688,11 @@
                                 {{ user.get_full_name|default:user.email|truncatechars:20 }}
                             </a>
                             <ul class="dropdown-menu dropdown-menu-end">
+                                {% if user.role == 'ADMIN_NATIONAL' %}
+                                <li><a class="dropdown-item" href="{% url 'accounts:national_admin_dashboard' %}">
+                                    <i class="fas fa-shield-alt me-2"></i>National Dashboard
+                                </a></li>
+                                {% endif %}
                                 <li><a class="dropdown-item" href="{% url 'accounts:profile' %}">
                                     <i class="fas fa-user me-2"></i>My Profile
                                 </a></li>

--- a/templates/home.html
+++ b/templates/home.html
@@ -92,6 +92,12 @@
               <img src="{% static 'images/safa_connect.png' %}" alt="Join SAFA - Player & Officials Registration"
                    class="img-fluid" style="max-width: 100%; height: auto; border: none; box-shadow: none;">
         </a>
+        <p class="mt-3">
+            <a href="{% url 'accounts:national_registration' %}" class="text-decoration-none">
+                <i class="fas fa-user-shield me-1"></i>
+                Register as an Administrator
+            </a>
+        </p>
       </div>
     </div>
     {% endif %}


### PR DESCRIPTION
This commit adds the necessary links to the front end to make the new administrator registration and dashboard pages accessible.

- A link to the National Administrator Dashboard is added to the main navigation bar and the user profile dropdown. This link is only visible to logged-in users with the 'ADMIN_NATIONAL' role.
- A link for 'Register as an Administrator' is added to the main home page to provide a clear entry point for new administrators.