### PR TITLE
Remove `safa_connect.js` from `national_registration.html` to prevent…

### DIFF
--- a/accounts/templates/accounts/national_registration.html
+++ b/accounts/templates/accounts/national_registration.html
@@ -327,6 +327,4 @@ document.addEventListener('DOMContentLoaded', function() {
     updateOrgFields();
 });
 </script>
-<script src="{% static 'js/safa_connect.js' %}"></script>
-
 {% endblock %}


### PR DESCRIPTION
… a javascript error that was blocking form submission.

Update tests for `NationalAdminRegistrationForm` to correctly handle dynamic querysets for dependent fields, which was causing the test suite to fail.