### PR TITLE
feat: Update superuser dashboard with online users and remove clutter

### DIFF
--- a/accounts/management/commands/show_online_users.py
+++ b/accounts/management/commands/show_online_users.py
@@ -1,0 +1,32 @@
+from django.core.management.base import BaseCommand
+from django.contrib.sessions.models import Session
+from django.utils import timezone
+from accounts.models import CustomUser
+
+class Command(BaseCommand):
+    help = 'Displays users who are currently online.'
+
+    def handle(self, *args, **options):
+        # Get all non-expired sessions
+        sessions = Session.objects.filter(expire_date__gte=timezone.now())
+
+        # Get user IDs from sessions
+        user_ids = []
+        for session in sessions:
+            session_data = session.get_decoded()
+            user_id = session_data.get('_auth_user_id')
+            if user_id:
+                user_ids.append(user_id)
+
+        if not user_ids:
+            self.stdout.write(self.style.SUCCESS('No users are currently online.'))
+            return
+
+        # Get user objects
+        online_users = CustomUser.objects.filter(id__in=user_ids).select_related('province', 'region')
+
+        self.stdout.write(self.style.SUCCESS(f'Found {len(online_users)} online user(s):'))
+        for user in online_users:
+            province = user.province.name if user.province else 'N/A'
+            region = user.region.name if user.region else 'N/A'
+            self.stdout.write(f'- {user.get_full_name()} ({user.email}) - Province: {province}, Region: {region}')

--- a/safa_connect/dashboard_views.py
+++ b/safa_connect/dashboard_views.py
@@ -3,8 +3,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.db.models import Sum, Count, Q
 from django.utils import timezone
 from datetime import timedelta
-from events.models import Stadium, InternationalMatch, Ticket, TicketGroup
-from supporters.models import SupporterProfile
+from django.contrib.sessions.models import Session
 from membership.models import Invoice
 from membership.models import Member
 from geography.models import Club
@@ -18,56 +17,18 @@ def superuser_dashboard(request):
     # Time ranges for analytics
     now = timezone.now()
     last_7_days = now - timedelta(days=7)
-    last_30_days = now - timedelta(days=30)
     
-    # ==== EVENTS & TICKETING METRICS ====
-    events_metrics = {
-        'total_stadiums': Stadium.objects.filter(is_active=True).count(),
-        'total_matches': InternationalMatch.objects.filter(is_active=True).count(),
-        'upcoming_matches': InternationalMatch.objects.filter(
-            match_date__gte=now, is_active=True
-        ).count(),
-        'total_tickets_sold': Ticket.objects.filter(status__in=['PAID', 'USED']).count(),
-        'tickets_revenue': Ticket.objects.filter(status__in=['PAID', 'USED']).aggregate(
-            total=Sum('final_price')
-        )['total'] or 0,
-        'recent_ticket_sales': Ticket.objects.filter(
-            purchased_at__gte=last_7_days
-        ).count(),
-    }
+    # ==== ONLINE USERS ====
+    sessions = Session.objects.filter(expire_date__gte=timezone.now())
+    user_ids = []
+    for session in sessions:
+        session_data = session.get_decoded()
+        user_id = session_data.get('_auth_user_id')
+        if user_id:
+            user_ids.append(user_id)
     
-    # Top selling matches
-    top_matches = InternationalMatch.objects.annotate(
-        sold_count=Count('tickets', filter=Q(tickets__status__in=['PAID', 'USED']))
-    ).filter(sold_count__gt=0).order_by('-sold_count')[:5]
-    
-    # Recent ticket sales
-    recent_tickets = Ticket.objects.filter(
-        purchased_at__gte=last_7_days
-    ).select_related('match', 'supporter__user', 'seat').order_by('-purchased_at')[:10]
-    
-    # ==== SUPPORTERS METRICS ====
-    supporters_metrics = {
-        'total_supporters': SupporterProfile.objects.count(),
-        'verified_supporters': SupporterProfile.objects.filter(is_verified=True).count(),
-        'new_supporters_7days': SupporterProfile.objects.filter(
-            created_at__gte=last_7_days
-        ).count(),
-        'supporters_with_location': SupporterProfile.objects.filter(
-            latitude__isnull=False, longitude__isnull=False
-        ).count(),
-    }
-    
-    # Supporters by membership type
-    supporters_by_type = SupporterProfile.objects.values('membership_type').annotate(
-        count=Count('id')
-    ).order_by('-count')
-    
-    # Supporters by province
-    supporters_by_province = SupporterProfile.objects.values('location_province').annotate(
-        count=Count('id')
-    ).order_by('-count')[:10]
-    
+    online_users = CustomUser.objects.filter(id__in=user_ids).select_related('province', 'region')
+
     # ==== INVOICES & REVENUE METRICS ====
     invoice_metrics = {
         'total_invoices': Invoice.objects.count(),
@@ -88,11 +49,6 @@ def superuser_dashboard(request):
         total_amount=Sum('total_amount')
     ).order_by('-total_amount')
     
-    # Recent invoices
-    recent_invoices = Invoice.objects.filter(
-        created__gte=last_7_days
-    ).order_by('-created')[:10]
-    
     # ==== MEMBERSHIP METRICS ====
     membership_metrics = {
         'total_members': Member.objects.count(),
@@ -105,32 +61,6 @@ def superuser_dashboard(request):
     # ==== RECENT ACTIVITY ====
     # Get recent activities across all modules
     recent_activities = []
-    
-    # Recent supporter registrations
-    for supporter in SupporterProfile.objects.filter(
-        created_at__gte=last_7_days
-    ).select_related('user')[:5]:
-        recent_activities.append({
-            'type': 'supporter_registration',
-            'title': f'New Supporter: {supporter.user.get_full_name()}',
-            'subtitle': f'{supporter.get_membership_type_display()}',
-            'timestamp': supporter.created_at,
-            'icon': 'bi-people-fill',
-            'color': 'success'
-        })
-    
-    # Recent ticket purchases
-    for ticket in Ticket.objects.filter(
-        purchased_at__gte=last_7_days
-    ).select_related('match', 'supporter__user')[:5]:
-        recent_activities.append({
-            'type': 'ticket_purchase',
-            'title': f'Ticket Purchase: {ticket.match.name}',
-            'subtitle': f'By {ticket.supporter.user.get_full_name()}',
-            'timestamp': ticket.purchased_at,
-            'icon': 'bi-ticket-perforated-fill',
-            'color': 'primary'
-        })
     
     # Recent invoice payments
     for invoice in Invoice.objects.filter(
@@ -154,16 +84,10 @@ def superuser_dashboard(request):
     pending_approvals = Member.objects.filter(status='PENDING').select_related('user', 'current_club')
 
     context = {
-        'events_metrics': events_metrics,
-        'supporters_metrics': supporters_metrics,
+        'online_users': online_users,
         'invoice_metrics': invoice_metrics,
         'membership_metrics': membership_metrics,
-        'top_matches': top_matches,
-        'recent_tickets': recent_tickets,
-        'supporters_by_type': supporters_by_type,
-        'supporters_by_province': supporters_by_province,
         'invoice_by_type': invoice_by_type,
-        'recent_invoices': recent_invoices,
         'recent_activities': recent_activities,
         'pending_approvals': pending_approvals,
     }

--- a/templates/admin/superuser_dashboard.html
+++ b/templates/admin/superuser_dashboard.html
@@ -17,8 +17,6 @@
             transform: translateY(-5px);
             box-shadow: 0 8px 25px rgba(0,0,0,0.15);
         }
-        .metric-card-events { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; }
-        .metric-card-supporters { background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%); color: white; }
         .metric-card-revenue { background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%); color: white; }
         .metric-card-membership { background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%); color: white; }
         
@@ -40,11 +38,6 @@
             margin-bottom: 20px;
         }
         
-        .chart-container {
-            position: relative;
-            height: 300px;
-        }
-        
         .quick-action-btn {
             border-radius: 10px;
             transition: all 0.2s ease;
@@ -64,9 +57,6 @@
                 <a class="nav-link" href="{% url 'admin:index' %}">
                     <i class="bi bi-house"></i> Admin Home
                 </a>
-                <a class="nav-link" href="{% url 'events:dashboard' %}">
-                    <i class="bi bi-calendar-event"></i> Events
-                </a>
                 <a class="nav-link" href="{% url 'admin_logout' %}">
                     <i class="bi bi-box-arrow-right"></i> Logout
                 </a>
@@ -77,27 +67,7 @@
     <div class="container-fluid my-4">
         <!-- Key Metrics Row -->
         <div class="row mb-4">
-            <div class="col-md-3">
-                <div class="card metric-card metric-card-events">
-                    <div class="card-body text-center">
-                        <i class="bi bi-calendar-event fs-1 mb-2"></i>
-                        <h3 class="mb-0">{{ events_metrics.total_matches }}</h3>
-                        <p class="mb-1">International Matches</p>
-                        <small>{{ events_metrics.upcoming_matches }} upcoming</small>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-3">
-                <div class="card metric-card metric-card-supporters">
-                    <div class="card-body text-center">
-                        <i class="bi bi-people fs-1 mb-2"></i>
-                        <h3 class="mb-0">{{ supporters_metrics.total_supporters|floatformat:0 }}</h3>
-                        <p class="mb-1">Total Supporters</p>
-                        <small>{{ supporters_metrics.verified_supporters }} verified</small>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-3">
+            <div class="col-md-6">
                 <div class="card metric-card metric-card-revenue">
                     <div class="card-body text-center">
                         <i class="bi bi-cash fs-1 mb-2"></i>
@@ -107,7 +77,7 @@
                     </div>
                 </div>
             </div>
-            <div class="col-md-3">
+            <div class="col-md-6">
                 <div class="card metric-card metric-card-membership">
                     <div class="card-body text-center">
                         <i class="bi bi-award fs-1 mb-2"></i>
@@ -130,72 +100,28 @@
                     </div>
                     <div class="card-body">
                         <div class="row">
-                            <div class="col-md-2">
-                                <a href="{% url 'admin:events_internationalmatch_add' %}" class="btn btn-outline-primary w-100 quick-action-btn mb-2">
-                                    <i class="bi bi-plus-circle d-block mb-1"></i>
-                                    <small>New Match</small>
-                                </a>
-                            </div>
-                            <div class="col-md-2">
-                                <a href="{% url 'admin:events_stadium_add' %}" class="btn btn-outline-success w-100 quick-action-btn mb-2">
-                                    <i class="bi bi-building-add d-block mb-1"></i>
-                                    <small>Add Stadium</small>
-                                </a>
-                            </div>
-                            <div class="col-md-2">
-                                <a href="{% url 'admin:supporters_supporterprofile_changelist' %}" class="btn btn-outline-info w-100 quick-action-btn mb-2">
-                                    <i class="bi bi-people d-block mb-1"></i>
-                                    <small>Supporters</small>
-                                </a>
-                            </div>
-                            <div class="col-md-2">
+                            <div class="col-md-3">
                                 <a href="{% url 'accounts:member_approvals_list' %}" class="btn btn-outline-warning w-100 quick-action-btn mb-2">
                                     <i class="bi bi-person-check d-block mb-1"></i>
                                     <small>Player Approvals</small>
                                 </a>
                             </div>
-                            <div class="col-md-2">
+                            <div class="col-md-3">
                                 <a href="{% url 'accounts:club_invoices' %}" class="btn btn-outline-danger w-100 quick-action-btn mb-2">
                                     <i class="bi bi-receipt-cutoff d-block mb-1"></i>
                                     <small>Club Invoices</small>
                                 </a>
                             </div>
-                            <div class="col-md-2">
+                            <div class="col-md-3">
                                 <a href="{% url 'admin:membership_member_changelist' %}" class="btn btn-outline-secondary w-100 quick-action-btn mb-2">
                                     <i class="bi bi-person-badge d-block mb-1"></i>
                                     <small>Members</small>
                                 </a>
                             </div>
-                        </div>
-                        <div class="row mt-2">
-                            <div class="col-md-2">
+                             <div class="col-md-3">
                                 <a href="{% url 'admin:membership_invoice_changelist' %}" class="btn btn-outline-info w-100 quick-action-btn mb-2">
                                     <i class="bi bi-receipt d-block mb-1"></i>
                                     <small>All Invoices</small>
-                                </a>
-                            </div>
-                            <div class="col-md-2">
-                                <a href="{% url 'admin:events_ticket_changelist' %}" class="btn btn-outline-primary w-100 quick-action-btn mb-2">
-                                    <i class="bi bi-ticket-perforated d-block mb-1"></i>
-                                    <small>Tickets</small>
-                                </a>
-                            </div>
-                            <div class="col-md-2">
-                                <a href="{% url 'accounts:club_invoices' %}?association=true" class="btn btn-outline-success w-100 quick-action-btn mb-2">
-                                    <i class="bi bi-building-gear d-block mb-1"></i>
-                                    <small>Assoc. Invoices</small>
-                                </a>
-                            </div>
-                            <div class="col-md-2">
-                                <a href="{% url 'accounts:admin_add_referee' %}" class="btn btn-outline-warning w-100 quick-action-btn mb-2">
-                                    <i class="bi bi-person-plus d-block mb-1"></i>
-                                    <small>Add Referee</small>
-                                </a>
-                            </div>
-                            <div class="col-md-2">
-                                <a href="{% url 'merchandise:store_home' %}" class="btn btn-outline-success w-100 quick-action-btn mb-2">
-                                    <i class="bi bi-shop d-block mb-1"></i>
-                                    <small>SAFA Store</small>
                                 </a>
                             </div>
                         </div>
@@ -205,77 +131,41 @@
         </div>
 
         <div class="row">
-            <!-- Events & Ticketing Section -->
-            <div class="col-lg-6 mb-4">
-                <div class="card h-100">
+            <!-- Online Users Section -->
+            <div class="col-12 mb-4">
+                <div class="card">
                     <div class="card-header bg-white">
                         <h5 class="section-header mb-0">
-                            <i class="bi bi-calendar-event text-primary"></i> Events & Ticketing
+                            <i class="bi bi-person-circle text-success"></i> Online Users
                         </h5>
                     </div>
                     <div class="card-body">
-                        <div class="row mb-3">
-                            <div class="col-6">
-                                <div class="text-center">
-                                    <h4 class="text-primary">{{ events_metrics.total_tickets_sold }}</h4>
-                                    <small class="text-muted">Tickets Sold</small>
-                                </div>
-                            </div>
-                            <div class="col-6">
-                                <div class="text-center">
-                                    <h4 class="text-success">R {{ events_metrics.tickets_revenue|floatformat:0 }}</h4>
-                                    <small class="text-muted">Ticket Revenue</small>
-                                </div>
-                            </div>
+                        {% if online_users %}
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover">
+                                <thead>
+                                    <tr>
+                                        <th>Name</th>
+                                        <th>Email</th>
+                                        <th>Province</th>
+                                        <th>Region</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for user in online_users %}
+                                    <tr>
+                                        <td>{{ user.get_full_name }}</td>
+                                        <td>{{ user.email }}</td>
+                                        <td>{{ user.province.name|default:"N/A" }}</td>
+                                        <td>{{ user.region.name|default:"N/A" }}</td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
                         </div>
-                        
-                        <h6 class="mb-3">Top Selling Matches</h6>
-                        {% for match in top_matches %}
-                        <div class="d-flex justify-content-between align-items-center mb-2">
-                            <div>
-                                <strong>{{ match.name|truncatechars:30 }}</strong><br>
-                                <small class="text-muted">{{ match.match_date|date:"M d, Y" }}</small>
-                            </div>
-                            <span class="badge bg-primary">{{ match.sold_count }} sold</span>
-                        </div>
-                        {% empty %}
-                        <p class="text-muted">No ticket sales yet</p>
-                        {% endfor %}
-                    </div>
-                </div>
-            </div>
-
-            <!-- Supporters Analytics -->
-            <div class="col-lg-6 mb-4">
-                <div class="card h-100">
-                    <div class="card-header bg-white">
-                        <h5 class="section-header mb-0">
-                            <i class="bi bi-people text-success"></i> Supporters Analytics
-                        </h5>
-                    </div>
-                    <div class="card-body">
-                        <div class="row mb-3">
-                            <div class="col-6">
-                                <div class="text-center">
-                                    <h4 class="text-success">{{ supporters_metrics.new_supporters_7days }}</h4>
-                                    <small class="text-muted">New This Week</small>
-                                </div>
-                            </div>
-                            <div class="col-6">
-                                <div class="text-center">
-                                    <h4 class="text-info">{{ supporters_metrics.supporters_with_location }}</h4>
-                                    <small class="text-muted">With Location</small>
-                                </div>
-                            </div>
-                        </div>
-                        
-                        <h6 class="mb-3">By Membership Type</h6>
-                        {% for type_data in supporters_by_type %}
-                        <div class="d-flex justify-content-between align-items-center mb-2">
-                            <span>{{ type_data.membership_type }}</span>
-                            <span class="badge bg-success">{{ type_data.count }}</span>
-                        </div>
-                        {% endfor %}
+                        {% else %}
+                        <p class="text-muted">No users are currently online.</p>
+                        {% endif %}
                     </div>
                 </div>
             </div>
@@ -340,21 +230,17 @@
                     </div>
                     <div class="card-body">
                         <div class="row mb-4">
-                            <div class="col-md-3 text-center">
+                            <div class="col-md-4 text-center">
                                 <h4 class="text-primary">{{ invoice_metrics.total_invoices }}</h4>
                                 <small class="text-muted">Total Invoices</small>
                             </div>
-                            <div class="col-md-3 text-center">
+                            <div class="col-md-4 text-center">
                                 <h4 class="text-warning">{{ invoice_metrics.pending_invoices }}</h4>
                                 <small class="text-muted">Pending</small>
                             </div>
-                            <div class="col-md-3 text-center">
+                            <div class="col-md-4 text-center">
                                 <h4 class="text-success">{{ invoice_metrics.paid_invoices }}</h4>
                                 <small class="text-muted">Paid</small>
-                            </div>
-                            <div class="col-md-3 text-center">
-                                <h4 class="text-info">{{ events_metrics.recent_ticket_sales }}</h4>
-                                <small class="text-muted">Recent Sales</small>
                             </div>
                         </div>
                         
@@ -411,27 +297,19 @@
                     </div>
                     <div class="card-body">
                         <div class="row">
-                            <div class="col-md-2 text-center">
-                                <h5 class="text-primary">{{ events_metrics.total_stadiums }}</h5>
-                                <small class="text-muted">Active Stadiums</small>
-                            </div>
-                            <div class="col-md-2 text-center">
+                            <div class="col-md-3 text-center">
                                 <h5 class="text-success">{{ membership_metrics.total_clubs }}</h5>
                                 <small class="text-muted">Registered Clubs</small>
                             </div>
-                            <div class="col-md-2 text-center">
+                            <div class="col-md-3 text-center">
                                 <h5 class="text-warning">{{ membership_metrics.total_players }}</h5>
                                 <small class="text-muted">Registered Players</small>
                             </div>
-                            <div class="col-md-2 text-center">
+                            <div class="col-md-3 text-center">
                                 <h5 class="text-info">{{ membership_metrics.total_users }}</h5>
                                 <small class="text-muted">System Users</small>
                             </div>
-                            <div class="col-md-2 text-center">
-                                <h5 class="text-danger">R {{ events_metrics.tickets_revenue|floatformat:0 }}</h5>
-                                <small class="text-muted">Event Revenue</small>
-                            </div>
-                            <div class="col-md-2 text-center">
+                            <div class="col-md-3 text-center">
                                 <h5 class="text-secondary">R {{ invoice_metrics.total_revenue|floatformat:0 }}</h5>
                                 <small class="text-muted">Total Revenue</small>
                             </div>


### PR DESCRIPTION
This commit updates the superuser dashboard to provide a more focused and useful experience.

The following changes have been made:

- A new "Online Users" panel has been added to the dashboard, which displays a list of currently logged-in users, including their name, email, province, and region.
- The "Events & Ticketing" and "Supporters Analytics" panels have been removed to reduce clutter.
- The corresponding logic for these panels has been removed from the `superuser_dashboard` view.
- The "Tickets" quick action button and the "Events" link in the navbar have also been removed.