### PR TITLE
Create universal user registration page

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -93,9 +93,9 @@
                    class="img-fluid" style="max-width: 100%; height: auto; border: none; box-shadow: none;">
         </a>
         <p class="mt-3">
-            <a href="{% url 'accounts:national_registration' %}" class="text-decoration-none">
-                <i class="fas fa-user-shield me-1"></i>
-                Register as an Administrator
+            <a href="{% url 'accounts:user_registration' %}" class="text-decoration-none">
+                <i class="fas fa-user-plus me-1"></i>
+                Register as a Player or Official
             </a>
         </p>
       </div>


### PR DESCRIPTION
This commit introduces a new universal user registration page that replaces the old, confusing "National Registration" page. The new page is for all member types (e.g., Player, Official) and resolves the issue where users were trying to use the administrator-only registration form to register as regular members.

The changes include:
- A new `user_registration` view and template.
- A new `RegistrationForm` that inherits from `forms.ModelForm`.
- Cascading dropdowns for geographic entities on the registration form.
- A new URL `/registration/` for the new registration page.
- An update to the home page to link to the new registration page.
- The removal of the old `national_registration` URL, view, and template.
- New tests for the `user_registration` view and `RegistrationForm`.
- A fix for a broken link on the home page that was pointing to the old `national_registration` URL.