### PR TITLE
fix: Resolve NameError for LFAComplianceForm

### DIFF
--- a/accounts/document_views.py
+++ b/accounts/document_views.py
@@ -27,7 +27,7 @@ def document_access_dashboard(request):
     allowed_roles = ['ADMIN_SYSTEM', 'ADMIN_COUNTRY', 'ADMIN_FEDERATION', 'ADMIN_PROVINCE', 'ADMIN_REGION', 'ADMIN_LOCAL_FED']
     if not (request.user.is_superuser or request.user.role in allowed_roles):
         messages.error(request, 'You do not have permission to access this dashboard.')
-        return redirect('accounts:home')
+        return redirect('accounts:modern_home')
     
     # Get date range from query params
     days = int(request.GET.get('days', 30))

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -47,6 +47,8 @@ class CustomUserManager(BaseUserManager):
 
 ROLES = (
     ('MEMBER', _('Member')),
+    ('PLAYER', _('Player')),
+    ('OFFICIAL', _('Official')),
     ('ADMIN_NATIONAL', _('National Federation Admin')),
     ('ADMIN_NATIONAL_ACCOUNTS', _('National Accounts Administrator')),
     ('ADMIN_PROVINCE', _('Provincial Administrator')),

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -9,8 +9,8 @@ app_name = 'accounts'
 urlpatterns = [
     path('login/', auth_views.LoginView.as_view(template_name='accounts/login.html'), name='login'),
     path('registration/', views.user_registration, name='user_registration'),
-    path('', modern_home, name='home'),
-    path('logout/', auth_views.LogoutView.as_view(next_page='home'), name='logout'),
+    path('', modern_home, name='modern_home'),
+    path('logout/', auth_views.LogoutView.as_view(next_page='accounts:modern_home'), name='logout'),
     path('club-admin/add-player/', views.club_admin_add_player, name='club_admin_add_player'),
     path('admin-add-referee/', views_admin_referees.admin_add_referee, name='admin_add_referee'),
     path('club-invoices/', views.club_invoices, name='club_invoices'),

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -21,6 +21,13 @@ from .forms import (AdvancedMemberSearchForm, ClubAdminAddPlayerForm,
                     ClubAdminRegistrationForm, ModernContactForm, ProfileForm,
                     RejectMemberForm, RegistrationForm, SettingsForm,
                     UpdateProfilePhotoForm, EditPlayerForm)
+from geography.forms import (
+    ProvinceComplianceForm,
+    RegionComplianceForm,
+    LFAComplianceForm,
+    AssociationComplianceForm,
+    ClubComplianceForm,
+)
 from .models import (CustomUser, Notification, OrganizationType, Position,
                    UserRole)
 from .utils import (generate_unique_safa_id, get_dashboard_stats,

--- a/accounts/views_admin_referees.py
+++ b/accounts/views_admin_referees.py
@@ -17,7 +17,7 @@ def admin_add_referee(request):
     if not (request.user.is_superuser or request.user.is_staff or 
             (hasattr(request.user, 'role') and request.user.role in allowed_roles)):
         messages.error(request, "You don't have permission to register referees.")
-        return redirect('accounts:home')
+        return redirect('accounts:modern_home')
     
     if request.method == 'POST':
         official_form = AssociationOfficialRegistrationForm(request.POST, request.FILES)

--- a/geography/tests_management.py
+++ b/geography/tests_management.py
@@ -104,6 +104,7 @@ class GeographyManagementViewTest(TestCase):
             'regions-0-id': self.region.id,
             'regions-0-name': 'New Region Name',
             'regions-0-code': 'NR',
+            'regions-0-province': self.province.id,
             'regions-0-description': 'New description',
             'regions-0-status': 'ACTIVE',
             'regions-0-is_compliant': 'on'

--- a/geography/views.py
+++ b/geography/views.py
@@ -1062,11 +1062,11 @@ def edit_club_logo(request):
     """View for club admins to edit their club's logo"""
     if not request.user.is_authenticated or request.user.role != 'CLUB_ADMIN':
         messages.error(request, 'You do not have permission to access this page.')
-        return redirect('accounts:home')
+        return redirect('accounts:modern_home')
     
     if not request.user.club:
         messages.error(request, 'Your user profile is not linked to a club. Please contact support.')
-        return redirect('accounts:home')
+        return redirect('accounts:modern_home')
     
     club = request.user.club
     
@@ -1075,7 +1075,7 @@ def edit_club_logo(request):
         if form.is_valid():
             form.save()
             messages.success(request, 'Club logo updated successfully!')
-            return redirect('accounts:home')
+            return redirect('accounts:modern_home')
     else:
         form = ClubLogoForm(instance=club)
     

--- a/membership/templates/membership/senior_membership_dashboard.html
+++ b/membership/templates/membership/senior_membership_dashboard.html
@@ -102,7 +102,7 @@
             {% endif %}
         </div>
         <div class="card-footer">
-            <a href="{% url 'accounts:home' %}" class="btn btn-secondary">Back to Dashboard</a>
+            <a href="{% url 'accounts:modern_home' %}" class="btn btn-secondary">Back to Dashboard</a>
         </div>
     </div>
 </div>

--- a/membership/views.py
+++ b/membership/views.py
@@ -15,7 +15,7 @@ from xhtml2pdf import pisa
 def registration_portal(request):
     """Registration portal with different registration options"""
     if request.user.is_authenticated:
-        return redirect('accounts:home')
+        return redirect('accounts:modern_home')
     context = {
         'title': 'SAFA Registration Portal',
     }

--- a/templates/membership_cards/no_card.html
+++ b/templates/membership_cards/no_card.html
@@ -186,7 +186,7 @@
         </div>
         
         <div class="mt-4">
-            <a href="{% url 'accounts:home' %}" class="back-button">
+            <a href="{% url 'accounts:modern_home' %}" class="back-button">
                 <i class="bi bi-arrow-left"></i>
                 Back to Dashboard
             </a>


### PR DESCRIPTION
This commit resolves a `NameError` that occurred when accessing the LFA compliance page. The error was caused by a missing import for `LFAComplianceForm` and other compliance-related forms in `accounts/views.py`.

This commit also includes fixes for the test suite, which was failing due to a combination of issues, including a URL naming conflict and incorrect test data.