### PR TITLE
Fix admin save, update dashboards, and add junior approval logic

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1344,6 +1344,7 @@ class ClubAdminRegistrationForm(forms.ModelForm):
     region = forms.ModelChoiceField(queryset=Region.objects.all(), required=False, disabled=True)
     lfa = forms.ModelChoiceField(queryset=LocalFootballAssociation.objects.all(), required=False, disabled=True, label="LFA")
     club = forms.ModelChoiceField(queryset=Club.objects.all(), required=False, disabled=True)
+    date_of_birth = forms.DateField(widget=forms.DateInput(attrs={'type': 'date'}), required=False)
 
     class Meta:
         model = CustomUser
@@ -1353,3 +1354,9 @@ class ClubAdminRegistrationForm(forms.ModelForm):
             'national_federation', 'province', 'region', 'lfa', 'club',
             'popi_act_consent', 'password', 'password2'
         ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field_name, field in self.fields.items():
+            if not isinstance(field.widget, forms.CheckboxInput):
+                field.widget.attrs.update({'class': 'form-control'})


### PR DESCRIPTION
This commit addresses several issues based on user feedback:

1.  **Fix Club Admin Save Logic:** Corrects a bug where geographic data for a new club administrator was not being saved to the database. The logic now correctly populates the user's province, region, etc., from the logged-in user's club.

2.  **Update Dashboards with Pending Members:** Modifies the national and superuser dashboards to display a list of all members who are currently pending approval, providing better visibility for administrators.

3.  **Conditional Junior Approval:** Implements logic to prevent the approval of junior members (under 18) if parental consent has not been provided. This includes disabling the approval button in the UI and adding a validation check in the backend to enforce the rule.

4.  **Add Date Picker:** Adds a date picker widget to the `date_of_birth` field on the "Add Club Administrator" form for improved user experience.