### PR TITLE
Fix member approvals list view and template

### DIFF
--- a/accounts/templates/accounts/member_approvals_list.html
+++ b/accounts/templates/accounts/member_approvals_list.html
@@ -27,47 +27,47 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for member in members_to_approve %}
-                        <tr id="member-row-{{ member.id }}">
-                            <td>{{ member.get_full_name }}</td>
-                            <td>{{ member.email|default:"N/A" }}</td>
-                            <td>{{ member.role|default:"N/A" }}</td>
-                            <td>{{ member.current_club.name|default:"N/A" }}</td>
-                            <td>{{ member.created|date:"Y-m-d" }}</td>
+                        {% for user in users_to_approve %}
+                        <tr id="member-row-{{ user.id }}">
+                            <td>{{ user.get_full_name }}</td>
+                            <td>{{ user.email|default:"N/A" }}</td>
+                            <td>{{ user.get_role_display }}</td>
+                            <td>{{ user.get_organization_info.name|default:"N/A" }}</td>
+                            <td>{{ user.date_joined|date:"Y-m-d" }}</td>
                             <td class="text-center">
                                 <form action="{% url 'accounts:member_approvals_list' %}" method="post" class="d-inline">
                                     {% csrf_token %}
-                                    <input type="hidden" name="member_id" value="{{ member.id }}">
-                                    {% if member.user.age < 18 and not member.user.parental_consent %}
+                                    <input type="hidden" name="member_id" value="{{ user.id }}">
+                                    {% if user.age < 18 and not user.parental_consent %}
                                         <button type="submit" name="approve" class="btn btn-success btn-sm" disabled title="Parental consent required for junior members">Approve</button>
                                     {% else %}
-                                        <button type="submit" name="approve" class="btn btn-success btn-sm">Approve</button>
+                                        <button type="submit" name="approve" class="btn btn-success btn-sm" value="approve">Approve</button>
                                     {% endif %}
                                 </form>
-                                <button type="button" class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#rejectModal-{{ member.id }}">
+                                <button type="button" class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#rejectModal-{{ user.id }}">
                                     Reject
                                 </button>
 
                                 <!-- Reject Modal -->
-                                <div class="modal fade" id="rejectModal-{{ member.id }}" tabindex="-1" aria-labelledby="rejectModalLabel-{{ member.id }}" aria-hidden="true">
+                                <div class="modal fade" id="rejectModal-{{ user.id }}" tabindex="-1" aria-labelledby="rejectModalLabel-{{ user.id }}" aria-hidden="true">
                                   <div class="modal-dialog">
                                     <div class="modal-content">
                                       <form action="{% url 'accounts:member_approvals_list' %}" method="post">
                                           {% csrf_token %}
-                                          <input type="hidden" name="member_id" value="{{ member.id }}">
+                                          <input type="hidden" name="member_id" value="{{ user.id }}">
                                           <div class="modal-header">
-                                            <h5 class="modal-title" id="rejectModalLabel-{{ member.id }}">Reject Member: {{ member.get_full_name }}</h5>
+                                            <h5 class="modal-title" id="rejectModalLabel-{{ user.id }}">Reject Member: {{ user.get_full_name }}</h5>
                                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                           </div>
                                           <div class="modal-body">
                                             <div class="mb-3">
-                                                <label for="rejection_reason-{{ member.id }}" class="form-label">Reason for Rejection</label>
-                                                <textarea class="form-control" id="rejection_reason-{{ member.id }}" name="rejection_reason" rows="3" required></textarea>
+                                                <label for="rejection_reason-{{ user.id }}" class="form-label">Reason for Rejection</label>
+                                                <textarea class="form-control" id="rejection_reason-{{ user.id }}" name="rejection_reason" rows="3" required></textarea>
                                             </div>
                                           </div>
                                           <div class="modal-footer">
                                             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                                            <button type="submit" name="reject" class="btn btn-danger">Confirm Rejection</button>
+                                            <button type="submit" name="reject" class="btn btn-danger" value="reject">Confirm Rejection</button>
                                           </div>
                                       </form>
                                     </div>


### PR DESCRIPTION
The `member_approvals_list` view and template had several inconsistencies that prevented the page from working correctly. This commit addresses these issues by:

- Changing the view to query `CustomUser` objects with a 'PENDING' membership status, instead of `Member` objects. This fixes the core data inconsistency.
- Updating the template to iterate over `users_to_approve` (a queryset of `CustomUser` objects) and use the correct attributes for displaying the user's information, including organization and registration date.
- Using `date_joined` instead of `registration_date` or `created` for consistency.
- Ensuring the approval and rejection logic in the view correctly handles `CustomUser` objects and their associated `Member` objects.
- Requiring a rejection reason when an admin rejects a member's application.