### PR TITLE
feat: Add member list to national admin dashboard

### DIFF
--- a/accounts/templates/accounts/member_approvals_list.html
+++ b/accounts/templates/accounts/member_approvals_list.html
@@ -2,86 +2,88 @@
 {% load static %}
 
 {% block content %}
+<div class="container mt-4">
+    <h2>Members Pending Approval</h2>
+    <hr>
 
-<div class="container mt-4"> <h2>Members Pending Approval</h2> <hr>
-text
-{% if messages %}
-    {% for message in messages %}
-        <div class="alert alert-{{ message.tags }}">{{ message }}</div>
-    {% endfor %}
-{% endif %}
+    {% if messages %}
+        {% for message in messages %}
+            <div class="alert alert-{{ message.tags }}">{{ message }}</div>
+        {% endfor %}
+    {% endif %}
 
-<div class="card shadow-sm">
-    <div class="card-body">
-        <div class="table-responsive">
-            <table class="table table-hover">
-                <thead class="table-light">
-                    <tr>
-                        <th>Name</th>
-                        <th>Email</th>
-                        <th>Role</th>
-                        <th>Organization</th>
-                        <th>Registration Date</th>
-                        <th class="text-center">Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for user in users_to_approve %}
-                    <tr id="member-row-{{ user.id }}">
-                        <td>{{ user.get_full_name }}</td>
-                        <td>{{ user.email|default:"N/A" }}</td>
-                        <td>{{ user.get_role_display }}</td>
-                        <td>{{ user.get_organization_info.name|default:"N/A" }}</td>
-                        <td>{{ user.date_joined|date:"Y-m-d" }}</td>
-                        <td class="text-center">
-                            <form action="{% url 'accounts:member_approvals_list' %}" method="post" class="d-inline">
-                                {% csrf_token %}
-                                <input type="hidden" name="member_id" value="{{ user.id }}">
-                                {% if user.age < 18 and not user.parental_consent %}
-                                    <button type="submit" name="approve" class="btn btn-success btn-sm" disabled title="Parental consent required for junior members">Approve</button>
-                                {% else %}
-                                    <button type="submit" name="approve" class="btn btn-success btn-sm" value="approve">Approve</button>
-                                {% endif %}
-                            </form>
-                            <button type="button" class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#rejectModal-{{ user.id }}">
-                                Reject
-                            </button>
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-hover">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Name</th>
+                            <th>Email</th>
+                            <th>Role</th>
+                            <th>Organization</th>
+                            <th>Registration Date</th>
+                            <th class="text-center">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for user in users_to_approve %}
+                        <tr id="member-row-{{ user.id }}">
+                            <td>{{ user.get_full_name }}</td>
+                            <td>{{ user.email|default:"N/A" }}</td>
+                            <td>{{ user.get_role_display }}</td>
+                            <td>{{ user.get_organization_info.name|default:"N/A" }}</td>
+                            <td>{{ user.date_joined|date:"Y-m-d" }}</td>
+                            <td class="text-center">
+                                <form action="{% url 'accounts:member_approvals_list' %}" method="post" class="d-inline">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="member_id" value="{{ user.id }}">
+                                    {% if user.age < 18 and not user.parental_consent %}
+                                        <button type="submit" name="approve" class="btn btn-success btn-sm" disabled title="Parental consent required for junior members">Approve</button>
+                                    {% else %}
+                                        <button type="submit" name="approve" class="btn btn-success btn-sm">Approve</button>
+                                    {% endif %}
+                                </form>
+                                <button type="button" class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#rejectModal-{{ user.id }}">
+                                    Reject
+                                </button>
 
-                            <!-- Reject Modal -->
-                            <div class="modal fade" id="rejectModal-{{ user.id }}" tabindex="-1" aria-labelledby="rejectModalLabel-{{ user.id }}" aria-hidden="true">
-                              <div class="modal-dialog">
-                                <div class="modal-content">
-                                  <form action="{% url 'accounts:member_approvals_list' %}" method="post">
-                                      {% csrf_token %}
-                                      <input type="hidden" name="member_id" value="{{ user.id }}">
-                                      <div class="modal-header">
-                                        <h5 class="modal-title" id="rejectModalLabel-{{ user.id }}">Reject Member: {{ user.get_full_name }}</h5>
-                                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                      </div>
-                                      <div class="modal-body">
-                                        <div class="mb-3">
-                                            <label for="rejection_reason-{{ user.id }}" class="form-label">Reason for Rejection</label>
-                                            <textarea class="form-control" id="rejection_reason-{{ user.id }}" name="rejection_reason" rows="3" required></textarea>
-                                        </div>
-                                      </div>
-                                      <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                                        <button type="submit" name="reject" class="btn btn-danger" value="reject">Confirm Rejection</button>
-                                      </div>
-                                  </form>
+                                <!-- Reject Modal -->
+                                <div class="modal fade" id="rejectModal-{{ user.id }}" tabindex="-1" aria-labelledby="rejectModalLabel-{{ user.id }}" aria-hidden="true">
+                                  <div class="modal-dialog">
+                                    <div class="modal-content">
+                                      <form action="{% url 'accounts:member_approvals_list' %}" method="post">
+                                          {% csrf_token %}
+                                          <input type="hidden" name="member_id" value="{{ user.id }}">
+                                          <div class="modal-header">
+                                            <h5 class="modal-title" id="rejectModalLabel-{{ user.id }}">Reject Member: {{ user.get_full_name }}</h5>
+                                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                          </div>
+                                          <div class="modal-body">
+                                            <div class="mb-3">
+                                                <label for="rejection_reason-{{ user.id }}" class="form-label">Reason for Rejection</label>
+                                                <textarea class="form-control" id="rejection_reason-{{ user.id }}" name="rejection_reason" rows="3" required></textarea>
+                                            </div>
+                                          </div>
+                                          <div class="modal-footer">
+                                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                            <button type="submit" name="reject" class="btn btn-danger">Confirm Rejection</button>
+                                          </div>
+                                      </form>
+                                    </div>
+                                  </div>
                                 </div>
-                              </div>
-                            </div>
-                        </td>
-                   </tr>
-                    {% empty %}
-                    <tr>
-                        <td colspan="6" class="text-center text-muted">No members are currently pending approval.</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                            </td>
+                        </tr>
+                        {% empty %}
+                        <tr>
+                            <td colspan="6" class="text-center text-muted">No members are currently pending approval.</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>
-</div> {% endblock %}
+{% endblock %}

--- a/accounts/templates/accounts/national_admin_dashboard.html
+++ b/accounts/templates/accounts/national_admin_dashboard.html
@@ -128,41 +128,61 @@
 
     <div class="card shadow-sm mb-4">
         <div class="card-header">
-            <h4 class="mb-0">Pending Member Approvals</h4>
+            <h4 class="mb-0">All Members</h4>
         </div>
         <div class="card-body">
-            {% if pending_members %}
             <div class="table-responsive">
                 <table class="table table-hover">
                     <thead class="table-light">
                         <tr>
-                            <th>Name</th>
+                            <th>Full Name</th>
                             <th>Email</th>
-                            <th>Role</th>
-                            <th>Date Registered</th>
+                            <th>Age</th>
+                            <th>Organization</th>
+                            <th>Status</th>
+                            <th>Gender</th>
                             <th class="text-center">Actions</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for member in pending_members %}
+                        {% for member in members_page %}
                         <tr>
                             <td>{{ member.get_full_name }}</td>
                             <td>{{ member.email }}</td>
-                            <td>{{ member.get_role_display }}</td>
-                            <td>{{ member.created|date:"Y-m-d" }}</td>
+                            <td>{{ member.age|default:"N/A" }}</td>
+                            <td>{{ member.get_organization_info.name|default:"N/A" }}</td>
+                            <td><span class="badge {% if member.membership_status == 'ACTIVE' %}bg-success{% elif member.membership_status == 'PENDING' %}bg-warning{% else %}bg-secondary{% endif %}">{{ member.get_membership_status_display }}</span></td>
+                            <td>{{ member.get_gender_display }}</td>
                             <td class="text-center">
-                                <a href="{% url 'accounts:member_approvals_list' %}" class="btn btn-primary btn-sm">
-                                    Review
+                                <a href="{% url 'accounts:edit_player' player_id=member.id %}" class="btn btn-primary btn-sm">
+                                    View
                                 </a>
                             </td>
+                        </tr>
+                        {% empty %}
+                        <tr>
+                            <td colspan="7" class="text-center text-muted">No members found.</td>
                         </tr>
                         {% endfor %}
                     </tbody>
                 </table>
             </div>
-            {% else %}
-            <p class="text-muted">No members are currently waiting for approval.</p>
-            {% endif %}
+
+            <nav aria-label="Member list navigation">
+                <ul class="pagination justify-content-center">
+                    {% if members_page.has_previous %}
+                        <li class="page-item"><a class="page-link" href="?member_page=1">&laquo; first</a></li>
+                        <li class="page-item"><a class="page-link" href="?member_page={{ members_page.previous_page_number }}">previous</a></li>
+                    {% endif %}
+
+                    <li class="page-item disabled"><a class="page-link" href="#">Page {{ members_page.number }} of {{ members_page.paginator.num_pages }}.</a></li>
+
+                    {% if members_page.has_next %}
+                        <li class="page-item"><a class="page-link" href="?member_page={{ members_page.next_page_number }}">next</a></li>
+                        <li class="page-item"><a class="page-link" href="?member_page={{ members_page.paginator.num_pages }}">last &raquo;</a></li>
+                    {% endif %}
+                </ul>
+            </nav>
         </div>
     </div>
 

--- a/accounts/templates/accounts/regional_admin_dashboard.html
+++ b/accounts/templates/accounts/regional_admin_dashboard.html
@@ -47,7 +47,7 @@
                         <li class="list-group-item d-flex justify-content-between align-items-center">
                             {{ lfa.name }}
                             <span class="badge bg-primary rounded-pill">{{ lfa.clubs.count }} Clubs</span>
-                            <a href="{% url 'geography:localfootballassociation-update' pk=lfa.id %}" class="btn btn-info btn-sm ms-2">Edit</a>
+                            <a href="{% url 'geography:lfa-update' pk=lfa.id %}" class="btn btn-info btn-sm ms-2">Edit</a>
                         </li>
                         {% endfor %}
                     </ul>

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -331,8 +331,6 @@ def member_approvals_list(request):
 
     if request.method == 'POST':
         user_id = request.POST.get('member_id') # The form sends member_id
-        action = request.POST.get('action')
-
         user = get_object_or_404(CustomUser, id=user_id)
 
         if 'approve' in request.POST:
@@ -709,7 +707,14 @@ def national_admin_dashboard(request):
     pending_associations = Association.objects.filter(status='INACTIVE')
     pending_clubs = Club.objects.filter(status='INACTIVE')
 
-    pending_members = CustomUser.objects.filter(membership_status='PENDING').order_by('-registration_date')
+    pending_members = Member.objects.filter(status='PENDING').select_related('user', 'current_club').order_by('-created')
+
+    # All Members list
+    all_members_list = CustomUser.objects.all().order_by('first_name', 'last_name')
+    member_paginator = Paginator(all_members_list, 10)
+    member_page_number = request.GET.get('member_page', 1)
+    members_page = member_paginator.get_page(member_page_number)
+
 
     context = {
         'org_data': org_data,
@@ -721,6 +726,7 @@ def national_admin_dashboard(request):
         'pending_lfas': pending_lfas,
         'pending_associations': pending_associations,
         'pending_clubs': pending_clubs,
+        'members_page': members_page,
     }
     return render(request, 'accounts/national_admin_dashboard.html', context)
 

--- a/membership/templates/membership/membership_profile_export_pdf.html
+++ b/membership/templates/membership/membership_profile_export_pdf.html
@@ -90,6 +90,7 @@
         <div class="profile-section">
             <h3>Identification</h3>
             <div class="profile-item"><strong>ID Document Type:</strong> {{ user.get_id_document_type_display|default:"N/A" }}</div>
+            <div class="profile-item"><strong>ID Number:</strong> {{ user.id_number|default:"N/A" }}</div>
             <div class="profile-item"><strong>Passport Number:</strong> {{ user.passport_number|default:"N/A" }}</div>
             {% if user.id_document %}
             <div class="profile-item"><strong>ID Document:</strong> <a href="{{ user.id_document.url }}">View Document</a></div>

--- a/safa_connect/dashboard_views.py
+++ b/safa_connect/dashboard_views.py
@@ -81,7 +81,7 @@ def superuser_dashboard(request):
     recent_activities = recent_activities[:15]  # Limit to 15 most recent
     
     # ==== PENDING APPROVALS ====
-    pending_approvals = CustomUser.objects.filter(membership_status='PENDING').order_by('-registration_date')
+    pending_approvals = Member.objects.filter(status='PENDING').select_related('user', 'current_club')
 
     context = {
         'online_users': online_users,


### PR DESCRIPTION
This commit introduces a new feature to the national admin dashboard: a paginated list of all members in the system. The list includes the member's full name, email, age, organization, status, and gender, with a link to view/edit each member's profile.

This also includes the fixes for the `member_approvals_list` view and template, ensuring that pending members can be correctly approved or rejected.