### PR TITLE
feat: Add second logo to home page

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -62,10 +62,14 @@
     {% if not user.is_authenticated %}
     <div class="row justify-content-center mt-4">
       <div class="col-md-8 text-center mb-4">
-          <a href="{% url 'membership:registration_portal' %}">
-              <img src="{% static 'images/safa_connect.png' %}" alt="Join SAFA - Player & Officials Registration"
-                   class="img-fluid" style="max-width: 100%; height: auto; border: none; box-shadow: none;">
-        </a>
+        <div class="d-flex justify-content-center align-items-center" style="gap: 1rem;">
+            <a href="{% url 'membership:registration_portal' %}">
+                <img src="{% static 'images/safa_connect.png' %}" alt="Join SAFA - Player & Officials Registration"
+                     class="img-fluid" style="max-width: 100%; height: auto; border: none; box-shadow: none;">
+            </a>
+            <img src="{% static 'images/safa_connect1.png' %}" alt="Connection 1 Logo"
+                 class="img-fluid" style="max-height: 120px; border: none; box-shadow: none;">
+        </div>
         <p class="mt-3">
             <a href="{% url 'accounts:user_registration' %}" class="text-decoration-none">
                 <i class="fas fa-user-plus me-1"></i>


### PR DESCRIPTION
This commit adds a second logo to the home page for unauthenticated users. The new logo is `static/images/safa_connect1.png` and is displayed next to the existing `safa_connect.png` logo.

The original request referred to `static/images/connection1`, which does not exist. It is assumed that `safa_connect1.png` was the intended image.