### PR TITLE
Fix user registration form and tests

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -58,6 +58,11 @@ ROLES = (
     ('ASSOCIATION_ADMIN', _('Association Administrator')),
 )
 
+REGISTRATION_ROLES = (
+    ('PLAYER', _('Player')),
+    ('OFFICIAL', _('Official')),
+)
+
 # Add new employment status choices
 EMPLOYMENT_STATUS = (
     ('EMPLOYEE', _('Full-time Employee')),

--- a/accounts/templates/accounts/user_registration.html
+++ b/accounts/templates/accounts/user_registration.html
@@ -12,6 +12,20 @@
             <form method="post" enctype="multipart/form-data" id="registrationForm" novalidate>
                 {% csrf_token %}
 
+                {% if form.non_field_errors %}
+                    <div class="alert alert-danger" role="alert">
+                        {% for error in form.non_field_errors %}
+                            <p class="mb-0">{{ error }}</p>
+                        {% endfor %}
+                    </div>
+                {% endif %}
+
+                {% if form.errors and not form.non_field_errors %}
+                     <div class="alert alert-danger" role="alert">
+                        <p class="mb-0">Please correct the errors highlighted below to continue.</p>
+                    </div>
+                {% endif %}
+
                 <div class="accordion" id="registrationAccordion">
 
                     <!-- Step 1: Role and Basic Info -->


### PR DESCRIPTION
This commit addresses an issue where the user registration form would fail silently without displaying validation errors.

- Modified `user_registration.html` to display non-field errors.
- Added a `clean_email` method to `RegistrationForm` to validate email uniqueness.
- Corrected the `RegistrationForm` logic to not require an association when a club admin creates an official.
- Fixed multiple issues in `tests_user_registration.py`, including incorrect test data and a `NameError`.

Note: The `test_add_club_administrator` test continues to fail with a `200 != 302` error, indicating an invalid form submission. The root cause for this test failure could not be determined despite extensive debugging.